### PR TITLE
Got jshint passing again after es6 transition

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,8 +23,7 @@
         "exports",
         "process",
 
-        "PlayerTest",
-        "TestHelpers",
+        "q",
         "asyncTest",
         "deepEqual",
         "equal",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -445,16 +445,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-browserify');
 
-  // grunt.loadTasks('./docs/tasks/');
-  // grunt.loadTasks('../videojs-doc-generator/tasks/');
-
   grunt.registerTask('pretask', ['jshint', 'less', 'vjslanguages', 'build', 'usebanner', 'uglify']);
   // Default task.
   grunt.registerTask('default', ['pretask', 'dist']);
   // Development watch task
   grunt.registerTask('dev', ['jshint', 'less', 'vjslanguages', 'build', 'usebanner', 'qunit:source']);
   grunt.registerTask('test-qunit', ['pretask', 'qunit']);
-  grunt.registerTask('test-es6', ['browserify:test', 'qunit:es6']);
 
   grunt.registerTask('dist', 'Creating distribution', ['dist-copy', 'zip:dist']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,7 +94,7 @@ module.exports = function(grunt) {
       es6: ['test/es6.html']
     },
     watch: {
-      files: [ 'src/**/*', 'test/unit/*.js', 'Gruntfile.js' ],
+      files: [ 'src/**/*', 'test/unit/**/*.js', 'Gruntfile.js' ],
       tasks: 'dev'
     },
     connect: {
@@ -449,7 +449,7 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', ['pretask', 'dist']);
   // Development watch task
-  grunt.registerTask('dev', ['jshint', 'less', 'vjslanguages', 'build', 'usebanner', 'qunit:source']);
+  grunt.registerTask('dev', ['jshint', 'less', 'vjslanguages', 'browserify:dist', 'usebanner', 'karma:chrome']);
   grunt.registerTask('test-qunit', ['pretask', 'qunit']);
 
   grunt.registerTask('dist', 'Creating distribution', ['dist-copy', 'zip:dist']);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-copy": "~0.3.2",
     "grunt-contrib-cssmin": "~0.6.0",
-    "grunt-contrib-jshint": "~0.11.0",
+    "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-less": "~0.6.4",
     "grunt-contrib-qunit": "~0.2.1",
     "grunt-contrib-uglify": "^0.8.0",

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -1,6 +1,6 @@
 import Component from './component';
-import * as VjsLib from './lib';
-import * as VjsEvents from './events';
+import * as Lib from './lib';
+import * as Events from './events';
 import document from 'global/document';
 
 /* Button - Base class for all buttons
@@ -33,7 +33,7 @@ Component.registerComponent('Button', Button);
 
 Button.prototype.createEl = function(type, props){
   // Add standard Aria and Tabindex info
-  props = VjsLib.obj.merge({
+  props = Lib.obj.merge({
     className: this.buildCSSClass(),
     'role': 'button',
     'aria-live': 'polite', // let the screen reader user know that the text of the button may change
@@ -44,11 +44,11 @@ Button.prototype.createEl = function(type, props){
 
   // if innerHTML hasn't been overridden (bigPlayButton), add content elements
   if (!props.innerHTML) {
-    this.contentEl_ = VjsLib.createEl('div', {
+    this.contentEl_ = Lib.createEl('div', {
       className: 'vjs-control-content'
     });
 
-    this.controlText_ = VjsLib.createEl('span', {
+    this.controlText_ = Lib.createEl('span', {
       className: 'vjs-control-text',
       innerHTML: this.localize(this.buttonText) || 'Need Text'
     });
@@ -70,7 +70,7 @@ Button.prototype.onClick = function(){};
 
   // Focus - Add keyboard functionality to element
 Button.prototype.onFocus = function(){
-  VjsEvents.on(document, 'keydown', VjsLib.bind(this, this.onKeyPress));
+  Events.on(document, 'keydown', Lib.bind(this, this.onKeyPress));
 };
 
   // KeyPress (document level) - Trigger click when keys are pressed
@@ -84,7 +84,7 @@ Button.prototype.onKeyPress = function(event){
 
 // Blur - Remove keyboard triggers
 Button.prototype.onBlur = function(){
-  VjsEvents.off(document, 'keydown', VjsLib.bind(this, this.onKeyPress));
+  Events.off(document, 'keydown', Lib.bind(this, this.onKeyPress));
 };
 
 export default Button;

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -4,9 +4,9 @@
  */
 
 import CoreObject from './core-object.js';
-import * as VjsLib from './lib.js';
+import * as Lib from './lib.js';
 import * as VjsUtil from './util.js';
-import * as VjsEvents from './events.js';
+import * as Events from './events.js';
 import window from 'global/window';
 
 /**
@@ -48,7 +48,7 @@ var Component = CoreObject.extend({
     this.player_ = player;
 
     // Make a copy of prototype.options_ to protect against overriding global defaults
-    this.options_ = VjsLib.obj.copy(this.options_);
+    this.options_ = Lib.obj.copy(this.options_);
 
     // Updated options with supplied options
     options = this.options(options);
@@ -59,7 +59,7 @@ var Component = CoreObject.extend({
     // If there was no ID from the options, generate one
     if (!this.id_) {
       // Don't require the player ID function in the case of mock players
-      this.id_ = ((player.id && player.id()) || 'no_player') + '_component_' + VjsLib.guid++;
+      this.id_ = ((player.id && player.id()) || 'no_player') + '_component_' + Lib.guid++;
     }
 
     this.name_ = options['name'] || null;
@@ -112,7 +112,7 @@ Component.prototype.dispose = function(){
     this.el_.parentNode.removeChild(this.el_);
   }
 
-  VjsLib.removeData(this.el_);
+  Lib.removeData(this.el_);
   this.el_ = null;
 };
 
@@ -204,7 +204,7 @@ Component.prototype.el_;
  * @return {Element}
  */
 Component.prototype.createEl = function(tagName, attributes){
-  return VjsLib.createEl(tagName, attributes);
+  return Lib.createEl(tagName, attributes);
 };
 
 Component.prototype.localize = function(string){
@@ -378,7 +378,7 @@ Component.prototype.addChild = function(child, options){
 
     // If no componentClass in options, assume componentClass is the name lowercased
     // (e.g. playButton)
-    let componentClassName = options['componentClass'] || VjsLib.capitalize(componentName);
+    let componentClassName = options['componentClass'] || Lib.capitalize(componentName);
 
     // Set name through options
     options['name'] = componentName;
@@ -514,7 +514,7 @@ Component.prototype.initChildren = function(){
     };
 
     // Allow for an array of children details to passed in the options
-    if (VjsLib.obj.isArray(children)) {
+    if (Lib.obj.isArray(children)) {
       for (var i = 0; i < children.length; i++) {
         let child = children[i];
 
@@ -532,7 +532,7 @@ Component.prototype.initChildren = function(){
         handleAdd(name, opts);
       }
     } else {
-      VjsLib.obj.each(children, handleAdd);
+      Lib.obj.each(children, handleAdd);
     }
   }
 };
@@ -586,14 +586,14 @@ Component.prototype.buildCSSClass = function(){
 Component.prototype.on = function(first, second, third){
   var target, type, fn, removeOnDispose, cleanRemover, thisComponent;
 
-  if (typeof first === 'string' || VjsLib.obj.isArray(first)) {
-    VjsEvents.on(this.el_, first, VjsLib.bind(this, second));
+  if (typeof first === 'string' || Lib.obj.isArray(first)) {
+    Events.on(this.el_, first, Lib.bind(this, second));
 
   // Targeting another component or element
   } else {
     target = first;
     type = second;
-    fn = VjsLib.bind(this, third);
+    fn = Lib.bind(this, third);
     thisComponent = this;
 
     // When this component is disposed, remove the listener from the other component
@@ -617,8 +617,8 @@ Component.prototype.on = function(first, second, third){
     // Check if this is a DOM node
     if (first.nodeName) {
       // Add the listener to the other element
-      VjsEvents.on(target, type, fn);
-      VjsEvents.on(target, 'dispose', cleanRemover);
+      Events.on(target, type, fn);
+      Events.on(target, 'dispose', cleanRemover);
 
     // Should be a component
     // Not using `instanceof vjs.Component` because it makes mock players difficult
@@ -655,13 +655,13 @@ Component.prototype.on = function(first, second, third){
 Component.prototype.off = function(first, second, third){
   var target, otherComponent, type, fn, otherEl;
 
-  if (!first || typeof first === 'string' || VjsLib.obj.isArray(first)) {
-    VjsEvents.off(this.el_, first, second);
+  if (!first || typeof first === 'string' || Lib.obj.isArray(first)) {
+    Events.off(this.el_, first, second);
   } else {
     target = first;
     type = second;
     // Ensure there's at least a guid, even if the function hasn't been used
-    fn = VjsLib.bind(this, third);
+    fn = Lib.bind(this, third);
 
     // Remove the dispose listener on this component,
     // which was given the same guid as the event listener
@@ -669,9 +669,9 @@ Component.prototype.off = function(first, second, third){
 
     if (first.nodeName) {
       // Remove the listener
-      VjsEvents.off(target, type, fn);
+      Events.off(target, type, fn);
       // Remove the listener for cleaning the dispose listener
-      VjsEvents.off(target, 'dispose', fn);
+      Events.off(target, 'dispose', fn);
     } else {
       target.off(type, fn);
       target.off('dispose', fn);
@@ -700,12 +700,12 @@ Component.prototype.off = function(first, second, third){
 Component.prototype.one = function(first, second, third) {
   var target, type, fn, thisComponent, newFunc;
 
-  if (typeof first === 'string' || VjsLib.obj.isArray(first)) {
-    VjsEvents.one(this.el_, first, VjsLib.bind(this, second));
+  if (typeof first === 'string' || Lib.obj.isArray(first)) {
+    Events.one(this.el_, first, Lib.bind(this, second));
   } else {
     target = first;
     type = second;
-    fn = VjsLib.bind(this, third);
+    fn = Lib.bind(this, third);
     thisComponent = this;
 
     newFunc = function(){
@@ -731,7 +731,7 @@ Component.prototype.one = function(first, second, third) {
  * @return {vjs.Component}       self
  */
 Component.prototype.trigger = function(event){
-  VjsEvents.trigger(this.el_, event);
+  Events.trigger(this.el_, event);
   return this;
 };
 
@@ -823,7 +823,7 @@ Component.prototype.triggerReady = function(){
  * @return {vjs.Component}
  */
 Component.prototype.hasClass = function(classToCheck){
-  return VjsLib.hasClass(this.el_, classToCheck);
+  return Lib.hasClass(this.el_, classToCheck);
 };
 
 /**
@@ -833,7 +833,7 @@ Component.prototype.hasClass = function(classToCheck){
  * @return {vjs.Component}
  */
 Component.prototype.addClass = function(classToAdd){
-  VjsLib.addClass(this.el_, classToAdd);
+  Lib.addClass(this.el_, classToAdd);
   return this;
 };
 
@@ -844,7 +844,7 @@ Component.prototype.addClass = function(classToAdd){
  * @return {vjs.Component}
  */
 Component.prototype.removeClass = function(classToRemove){
-  VjsLib.removeClass(this.el_, classToRemove);
+  Lib.removeClass(this.el_, classToRemove);
   return this;
 };
 
@@ -1006,7 +1006,7 @@ Component.prototype.dimension = function(widthOrHeight, num, skipListeners){
   // TODO: handle display:none and no dimension style using px
   } else {
 
-    return parseInt(this.el_['offset'+VjsLib.capitalize(widthOrHeight)], 10);
+    return parseInt(this.el_['offset'+Lib.capitalize(widthOrHeight)], 10);
 
     // ComputedStyle version.
     // Only difference is if the element is hidden it will return
@@ -1057,7 +1057,7 @@ Component.prototype.emitTapEvents = function(){
   this.on('touchstart', function(event) {
     // If more than one finger, don't consider treating this as a click
     if (event.touches.length === 1) {
-      firstTouch = VjsLib.obj.copy(event.touches[0]);
+      firstTouch = Lib.obj.copy(event.touches[0]);
       // Record start time so we can detect a tap vs. "touch and hold"
       touchStart = new Date().getTime();
       // Reset couldBeTap tracking
@@ -1140,7 +1140,7 @@ Component.prototype.enableTouchActivity = function() {
   }
 
   // listener for reporting that the user is active
-  report = VjsLib.bind(this.player(), this.player().reportUserActivity);
+  report = Lib.bind(this.player(), this.player().reportUserActivity);
 
   this.on('touchstart', function() {
     report();
@@ -1170,7 +1170,7 @@ Component.prototype.enableTouchActivity = function() {
  * @return {Number} Returns the timeout ID
  */
 Component.prototype.setTimeout = function(fn, timeout) {
-  fn = VjsLib.bind(this, fn);
+  fn = Lib.bind(this, fn);
 
   // window.setTimeout would be preferable here, but due to some bizarre issue with Sinon and/or Phantomjs, we can't.
   var timeoutId = setTimeout(fn, timeout);
@@ -1210,7 +1210,7 @@ Component.prototype.clearTimeout = function(timeoutId) {
  * @return {Number} Returns the interval ID
  */
 Component.prototype.setInterval = function(fn, interval) {
-  fn = VjsLib.bind(this, fn);
+  fn = Lib.bind(this, fn);
 
   var intervalId = setInterval(fn, interval);
 
@@ -1254,7 +1254,7 @@ Component.getComponent = function(name){
   }
 
   if (window && window.videojs && window.videojs[name]) {
-    VjsLib.log.warn('The '+name+' component was added to the videojs object when it should be registered using videojs.registerComponent');
+    Lib.log.warn('The '+name+' component was added to the videojs object when it should be registered using videojs.registerComponent');
     return window.videojs[name];
   }
 };

--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -1,5 +1,5 @@
 import Component from '../component';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 
 import PlayToggle from './play-toggle';
 import CurrentTimeDisplay from './time-display';
@@ -45,7 +45,7 @@ ControlBar.prototype.options_ = {
 };
 
 ControlBar.prototype.createEl = function(){
-  return VjsLib.createEl('div', {
+  return Lib.createEl('div', {
     className: 'vjs-control-bar'
   });
 };

--- a/src/js/control-bar/live-display.js
+++ b/src/js/control-bar/live-display.js
@@ -1,5 +1,5 @@
 import Component from '../component';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 
 /**
  * Displays the live indicator
@@ -21,7 +21,7 @@ LiveDisplay.prototype.createEl = function(){
     className: 'vjs-live-controls vjs-control'
   });
 
-  this.contentEl_ = VjsLib.createEl('div', {
+  this.contentEl_ = Lib.createEl('div', {
     className: 'vjs-live-display',
     innerHTML: '<span class="vjs-control-text">' + this.localize('Stream Type') + '</span>' + this.localize('LIVE'),
     'aria-live': 'off'

--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -1,6 +1,6 @@
 import Button from '../button';
 import Component from '../component';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 
 /**
  * A button component for muting the audio
@@ -69,9 +69,9 @@ MuteToggle.prototype.update = function(){
 
   /* TODO improve muted icon classes */
   for (var i = 0; i < 4; i++) {
-    VjsLib.removeClass(this.el_, 'vjs-vol-'+i);
+    Lib.removeClass(this.el_, 'vjs-vol-'+i);
   }
-  VjsLib.addClass(this.el_, 'vjs-vol-'+level);
+  Lib.addClass(this.el_, 'vjs-vol-'+level);
 };
 
 Component.registerComponent('MuteToggle', MuteToggle);

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -1,6 +1,6 @@
 import Button from '../button';
 import Component from '../component';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 
 /**
  * Button to toggle between play and pause

--- a/src/js/control-bar/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu-button.js
@@ -1,6 +1,6 @@
 import Component from '../component';
 import Menu, { MenuButton, MenuItem } from '../menu';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 
 /**
  * The component for controlling the playback rate
@@ -22,15 +22,13 @@ let PlaybackRateMenuButton = MenuButton.extend({
   }
 });
 
-Component.registerComponent('PlaybackRateMenuButton', PlaybackRateMenuButton);
-
 PlaybackRateMenuButton.prototype.buttonText = 'Playback Rate';
 PlaybackRateMenuButton.prototype.className = 'vjs-playback-rate';
 
 PlaybackRateMenuButton.prototype.createEl = function(){
   let el = MenuButton.prototype.createEl.call(this);
 
-  this.labelEl_ = VjsLib.createEl('div', {
+  this.labelEl_ = Lib.createEl('div', {
     className: 'vjs-playback-rate-value',
     innerHTML: 1.0
   });
@@ -109,7 +107,7 @@ PlaybackRateMenuButton.prototype.updateLabel = function(){
  *
  * @constructor
  */
-let PlaybackRateMenuItem = MenuItem.extend({
+var PlaybackRateMenuItem = MenuItem.extend({
   contentElType: 'button',
   /** @constructor */
   init: function(player, options){
@@ -136,5 +134,6 @@ PlaybackRateMenuItem.prototype.update = function(){
   this.selected(this.player().playbackRate() == this.rate);
 };
 
+Component.registerComponent('PlaybackRateMenuButton', PlaybackRateMenuButton);
 export default PlaybackRateMenuButton;
 export { PlaybackRateMenuItem };

--- a/src/js/control-bar/progress-control.js
+++ b/src/js/control-bar/progress-control.js
@@ -1,6 +1,6 @@
 import Component from '../component';
 import Slider, { SliderHandle } from '../slider';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 
 /**
  * The Progress Control component contains the seek bar, load progress,
@@ -43,7 +43,7 @@ var SeekBar = Slider.extend({
   init: function(player, options){
     Slider.call(this, player, options);
     this.on(player, 'timeupdate', this.updateARIAAttributes);
-    player.ready(VjsLib.bind(this, this.updateARIAAttributes));
+    player.ready(Lib.bind(this, this.updateARIAAttributes));
   }
 });
 
@@ -71,8 +71,8 @@ SeekBar.prototype.createEl = function(){
 SeekBar.prototype.updateARIAAttributes = function(){
     // Allows for smooth scrubbing, when player can't keep up.
     let time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
-    this.el_.setAttribute('aria-valuenow', VjsLib.round(this.getPercent()*100, 2)); // machine readable value of progress bar (percentage complete)
-    this.el_.setAttribute('aria-valuetext', VjsLib.formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
+    this.el_.setAttribute('aria-valuenow', Lib.round(this.getPercent()*100, 2)); // machine readable value of progress bar (percentage complete)
+    this.el_.setAttribute('aria-valuetext', Lib.formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
 };
 
 SeekBar.prototype.getPercent = function(){
@@ -163,7 +163,7 @@ LoadProgressBar.prototype.update = function(){
     let part = children[i];
 
     if (!part) {
-      part = this.el_.appendChild(VjsLib.createEl());
+      part = this.el_.appendChild(Lib.createEl());
     }
 
     // set the percent based on the width of the progress bar (bufferedEnd)
@@ -184,7 +184,7 @@ LoadProgressBar.prototype.update = function(){
  * @param {Object=} options
  * @constructor
  */
-let PlayProgressBar = Component.extend({
+var PlayProgressBar = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -235,7 +235,7 @@ SeekHandle.prototype.createEl = function() {
 
 SeekHandle.prototype.updateContent = function() {
   let time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
-  this.el_.innerHTML = '<span class="vjs-control-text">' + VjsLib.formatTime(time, this.player_.duration()) + '</span>';
+  this.el_.innerHTML = '<span class="vjs-control-text">' + Lib.formatTime(time, this.player_.duration()) + '</span>';
 };
 
 export default ProgressControl;

--- a/src/js/control-bar/time-display.js
+++ b/src/js/control-bar/time-display.js
@@ -1,5 +1,5 @@
 import Component from '../component';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 
 /**
  * Displays the current time
@@ -23,7 +23,7 @@ CurrentTimeDisplay.prototype.createEl = function(){
     className: 'vjs-current-time vjs-time-controls vjs-control'
   });
 
-  this.contentEl_ = VjsLib.createEl('div', {
+  this.contentEl_ = Lib.createEl('div', {
     className: 'vjs-current-time-display',
     innerHTML: '<span class="vjs-control-text">Current Time </span>' + '0:00', // label the current time for screen reader users
     'aria-live': 'off' // tell screen readers not to automatically read the time as it changes
@@ -36,7 +36,7 @@ CurrentTimeDisplay.prototype.createEl = function(){
 CurrentTimeDisplay.prototype.updateContent = function(){
   // Allows for smooth scrubbing, when player can't keep up.
   let time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
-  this.contentEl_.innerHTML = '<span class="vjs-control-text">' + this.localize('Current Time') + '</span> ' + VjsLib.formatTime(time, this.player_.duration());
+  this.contentEl_.innerHTML = '<span class="vjs-control-text">' + this.localize('Current Time') + '</span> ' + Lib.formatTime(time, this.player_.duration());
 };
 
 /**
@@ -45,7 +45,7 @@ CurrentTimeDisplay.prototype.updateContent = function(){
  * @param {Object=} options
  * @constructor
  */
-let DurationDisplay = Component.extend({
+var DurationDisplay = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -66,7 +66,7 @@ DurationDisplay.prototype.createEl = function(){
     className: 'vjs-duration vjs-time-controls vjs-control'
   });
 
-  this.contentEl_ = VjsLib.createEl('div', {
+  this.contentEl_ = Lib.createEl('div', {
     className: 'vjs-duration-display',
     innerHTML: '<span class="vjs-control-text">' + this.localize('Duration Time') + '</span> ' + '0:00', // label the duration time for screen reader users
     'aria-live': 'off' // tell screen readers not to automatically read the time as it changes
@@ -79,7 +79,7 @@ DurationDisplay.prototype.createEl = function(){
 DurationDisplay.prototype.updateContent = function(){
   let duration = this.player_.duration();
   if (duration) {
-    this.contentEl_.innerHTML = '<span class="vjs-control-text">' + this.localize('Duration Time') + '</span> ' + VjsLib.formatTime(duration); // label the duration time for screen reader users
+    this.contentEl_.innerHTML = '<span class="vjs-control-text">' + this.localize('Duration Time') + '</span> ' + Lib.formatTime(duration); // label the duration time for screen reader users
   }
 };
 
@@ -92,7 +92,7 @@ DurationDisplay.prototype.updateContent = function(){
  * @param {Object=} options
  * @constructor
  */
-let TimeDivider = Component.extend({
+var TimeDivider = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -114,7 +114,7 @@ TimeDivider.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-let RemainingTimeDisplay = Component.extend({
+var RemainingTimeDisplay = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -130,7 +130,7 @@ RemainingTimeDisplay.prototype.createEl = function(){
     className: 'vjs-remaining-time vjs-time-controls vjs-control'
   });
 
-  this.contentEl_ = VjsLib.createEl('div', {
+  this.contentEl_ = Lib.createEl('div', {
     className: 'vjs-remaining-time-display',
     innerHTML: '<span class="vjs-control-text">' + this.localize('Remaining Time') + '</span> ' + '-0:00', // label the remaining time for screen reader users
     'aria-live': 'off' // tell screen readers not to automatically read the time as it changes
@@ -142,7 +142,7 @@ RemainingTimeDisplay.prototype.createEl = function(){
 
 RemainingTimeDisplay.prototype.updateContent = function(){
   if (this.player_.duration()) {
-    this.contentEl_.innerHTML = '<span class="vjs-control-text">' + this.localize('Remaining Time') + '</span> ' + '-'+ VjsLib.formatTime(this.player_.remainingTime());
+    this.contentEl_.innerHTML = '<span class="vjs-control-text">' + this.localize('Remaining Time') + '</span> ' + '-'+ Lib.formatTime(this.player_.remainingTime());
   }
 
   // Allows for smooth scrubbing, when player can't keep up.

--- a/src/js/control-bar/volume-control.js
+++ b/src/js/control-bar/volume-control.js
@@ -1,5 +1,5 @@
 import Component from '../component';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 import Slider, { SliderHandle } from '../slider';
 
 /**
@@ -49,12 +49,12 @@ VolumeControl.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-let VolumeBar = Slider.extend({
+var VolumeBar = Slider.extend({
   /** @constructor */
   init: function(player, options){
     Slider.call(this, player, options);
     this.on(player, 'volumechange', this.updateARIAAttributes);
-    player.ready(VjsLib.bind(this, this.updateARIAAttributes));
+    player.ready(Lib.bind(this, this.updateARIAAttributes));
   }
 });
 
@@ -62,8 +62,8 @@ Component.registerComponent('VolumeBar', VolumeBar);
 
 VolumeBar.prototype.updateARIAAttributes = function(){
   // Current value of volume bar as a percentage
-  this.el_.setAttribute('aria-valuenow', VjsLib.round(this.player_.volume()*100, 2));
-  this.el_.setAttribute('aria-valuetext', VjsLib.round(this.player_.volume()*100, 2)+'%');
+  this.el_.setAttribute('aria-valuenow', Lib.round(this.player_.volume()*100, 2));
+  this.el_.setAttribute('aria-valuetext', Lib.round(this.player_.volume()*100, 2)+'%');
 };
 
 VolumeBar.prototype.options_ = {
@@ -115,7 +115,7 @@ VolumeBar.prototype.stepBack = function(){
  * @param {Object=} options
  * @constructor
  */
-let VolumeLevel = Component.extend({
+var VolumeLevel = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -138,7 +138,7 @@ VolumeLevel.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-let VolumeHandle = SliderHandle.extend();
+var VolumeHandle = SliderHandle.extend();
 
 Component.registerComponent('VolumeHandle', VolumeHandle);
 
@@ -152,4 +152,4 @@ VolumeHandle.prototype.createEl = function(){
 };
 
 export default VolumeControl;
-export { VolumeBar, VolumeLevel, VolumeHandle }
+export { VolumeBar, VolumeLevel, VolumeHandle };

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -2,7 +2,7 @@ import Button from '../button';
 import Component from '../component';
 import Menu, { MenuButton } from '../menu';
 import MuteToggle from './mute-toggle';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 import { VolumeBar } from './volume-control';
 
 /**

--- a/src/js/core-object.js
+++ b/src/js/core-object.js
@@ -1,4 +1,4 @@
-import * as VjsLib from './lib';
+import * as Lib from './lib';
 
 /**
  * Core Object/Class for objects that use inheritance + constructors
@@ -89,7 +89,7 @@ CoreObject.extend = function(props){
   };
 
   // Inherit from this object's prototype
-  subObj.prototype = VjsLib.obj.create(this.prototype);
+  subObj.prototype = Lib.obj.create(this.prototype);
   // Reset the constructor property for subObj otherwise
   // instances of subObj would have the constructor of the parent Object
   subObj.prototype.constructor = subObj;
@@ -119,7 +119,7 @@ CoreObject.extend = function(props){
  */
 CoreObject.create = function(){
   // Create a new object that inherits from this object's prototype
-  var inst = VjsLib.obj.create(this.prototype);
+  var inst = Lib.obj.create(this.prototype);
 
   // Apply this constructor function to the new object
   this.apply(inst, arguments);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -5,7 +5,7 @@
 import Player from './player';
 import Plugins from './plugins';
 import Options from './options';
-import * as VjsLib from './lib';
+import * as Lib from './lib';
 import * as VjsUtil from './util';
 import CoreObject from './core-object';
 import document from 'global/document';
@@ -43,7 +43,7 @@ var videojs = function(id, options, ready){
 
       // If options or ready funtion are passed, warn
       if (options) {
-        VjsLib.log.warn ('Player "' + id + '" is already initialised. Options will not be applied.');
+        Lib.log.warn ('Player "' + id + '" is already initialised. Options will not be applied.');
       }
 
       if (ready) {
@@ -54,7 +54,7 @@ var videojs = function(id, options, ready){
 
     // Otherwise get element for ID
     } else {
-      tag = VjsLib.el(id);
+      tag = Lib.el(id);
     }
 
   // ID is a media element

--- a/src/js/error-display.js
+++ b/src/js/error-display.js
@@ -1,5 +1,5 @@
 import Component from './component';
-import * as VjsLib from './lib';
+import * as Lib from './lib';
 
 /**
  * Display that an error has occurred making the video unplayable
@@ -23,7 +23,7 @@ ErrorDisplay.prototype.createEl = function(){
     className: 'vjs-error-display'
   });
 
-  this.contentEl_ = VjsLib.createEl('div');
+  this.contentEl_ = Lib.createEl('div');
   el.appendChild(this.contentEl_);
 
   return el;

--- a/src/js/event-emitter.js
+++ b/src/js/event-emitter.js
@@ -1,5 +1,5 @@
-import * as VjsEvents from './events';
-import * as VjsLib from './lib';
+import * as Events from './events';
+import * as Lib from './lib';
 
 var EventEmitter = function() {};
 
@@ -10,18 +10,18 @@ EventEmitter.prototype.on = function(type, fn) {
   // so we don't get into an infinite type loop
   let ael = this.addEventListener;
   this.addEventListener = Function.prototype;
-  VjsEvents.on(this, type, fn);
+  Events.on(this, type, fn);
   this.addEventListener = ael;
 };
 EventEmitter.prototype.addEventListener = EventEmitter.prototype.on;
 
 EventEmitter.prototype.off = function(type, fn) {
-  VjsEvents.off(this, type, fn);
+  Events.off(this, type, fn);
 };
 EventEmitter.prototype.removeEventListener = EventEmitter.prototype.off;
 
 EventEmitter.prototype.one = function(type, fn) {
-  VjsEvents.one(this, type, fn);
+  Events.one(this, type, fn);
 };
 
 EventEmitter.prototype.trigger = function(event) {
@@ -32,13 +32,13 @@ EventEmitter.prototype.trigger = function(event) {
       type: type
     };
   }
-  event = VjsEvents.fixEvent(event);
+  event = Events.fixEvent(event);
 
   if (this.allowedEvents_[type] && this['on' + type]) {
     this['on' + type](event);
   }
 
-  VjsEvents.trigger(this, event);
+  Events.trigger(this, event);
 };
 // The standard DOM EventTarget.dispatchEvent() is aliased to trigger()
 EventEmitter.prototype.dispatchEvent = EventEmitter.prototype.trigger;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -5,7 +5,7 @@
  * robust as jquery's, so there's probably some differences.
  */
 
-import * as VjsLib from './lib';
+import * as Lib from './lib';
 import window from 'global/window';
 import document from 'global/document';
 
@@ -15,7 +15,7 @@ import document from 'global/document';
  * @return {Object}
  * @private
  */
-let fixEvent = function(event) {
+var fixEvent = function(event) {
 
   function returnTrue() { return true; }
   function returnFalse() { return false; }
@@ -129,19 +129,19 @@ let fixEvent = function(event) {
  * @param  {Function} fn   Event listener.
  * @private
  */
-let on = function(elem, type, fn){
-  if (VjsLib.obj.isArray(type)) {
+var on = function(elem, type, fn){
+  if (Lib.obj.isArray(type)) {
     return _handleMultipleEvents(on, elem, type, fn);
   }
 
-  let data = VjsLib.getData(elem);
+  let data = Lib.getData(elem);
 
   // We need a place to store all our handler data
   if (!data.handlers) data.handlers = {};
 
   if (!data.handlers[type]) data.handlers[type] = [];
 
-  if (!fn.guid) fn.guid = VjsLib.guid++;
+  if (!fn.guid) fn.guid = Lib.guid++;
 
   data.handlers[type].push(fn);
 
@@ -186,16 +186,16 @@ let on = function(elem, type, fn){
  * @param  {Function} fn   Specific listener to remove. Don't include to remove listeners for an event type.
  * @private
  */
-let off = function(elem, type, fn) {
+var off = function(elem, type, fn) {
   // Don't want to add a cache object through getData if not needed
-  if (!VjsLib.hasData(elem)) return;
+  if (!Lib.hasData(elem)) return;
 
-  let data = VjsLib.getData(elem);
+  let data = Lib.getData(elem);
 
   // If no events exist, nothing to unbind
   if (!data.handlers) { return; }
 
-  if (VjsLib.obj.isArray(type)) {
+  if (Lib.obj.isArray(type)) {
     return _handleMultipleEvents(off, elem, type, fn);
   }
 
@@ -240,8 +240,8 @@ let off = function(elem, type, fn) {
  * @param  {String} type Type of event to clean up
  * @private
  */
-let cleanUpEvents = function(elem, type) {
-  var data = VjsLib.getData(elem);
+var cleanUpEvents = function(elem, type) {
+  var data = Lib.getData(elem);
 
   // Remove the events of a particular type if there are none left
   if (data.handlers[type].length === 0) {
@@ -258,7 +258,7 @@ let cleanUpEvents = function(elem, type) {
   }
 
   // Remove the events object if there are no types left
-  if (VjsLib.isEmpty(data.handlers)) {
+  if (Lib.isEmpty(data.handlers)) {
     delete data.handlers;
     delete data.dispatcher;
     delete data.disabled;
@@ -269,8 +269,8 @@ let cleanUpEvents = function(elem, type) {
   }
 
   // Finally remove the expando if there is no data left
-  if (VjsLib.isEmpty(data)) {
-    VjsLib.removeData(elem);
+  if (Lib.isEmpty(data)) {
+    Lib.removeData(elem);
   }
 };
 
@@ -280,11 +280,11 @@ let cleanUpEvents = function(elem, type) {
  * @param  {Event|Object|String} event A string (the type) or an event object with a type attribute
  * @private
  */
-let trigger = function(elem, event) {
+var trigger = function(elem, event) {
   // Fetches element data and a reference to the parent (for bubbling).
   // Don't want to add a data object to cache for every parent,
   // so checking hasData first.
-  var elemData = (VjsLib.hasData(elem)) ? VjsLib.getData(elem) : {};
+  var elemData = (Lib.hasData(elem)) ? Lib.getData(elem) : {};
   var parent = elem.parentNode || elem.ownerDocument;
       // type = event.type || event,
       // handler;
@@ -308,7 +308,7 @@ let trigger = function(elem, event) {
 
   // If at the top of the DOM, triggers the default action unless disabled.
   } else if (!parent && !event.defaultPrevented) {
-    var targetData = VjsLib.getData(event.target);
+    var targetData = Lib.getData(event.target);
 
     // Checks if the target has a default action for this event.
     if (event.target[event.type]) {
@@ -353,8 +353,8 @@ let trigger = function(elem, event) {
  * @param  {Function} fn
  * @private
  */
-let one = function(elem, type, fn) {
-  if (VjsLib.obj.isArray(type)) {
+var one = function(elem, type, fn) {
+  if (Lib.obj.isArray(type)) {
     return _handleMultipleEvents(one, elem, type, fn);
   }
   var func = function(){
@@ -362,7 +362,7 @@ let one = function(elem, type, fn) {
     fn.apply(this, arguments);
   };
   // copy the guid to the new function so it can removed using the original function's ID
-  func.guid = fn.guid = fn.guid || VjsLib.guid++;
+  func.guid = fn.guid = fn.guid || Lib.guid++;
   on(elem, type, func);
 };
 
@@ -375,7 +375,7 @@ let one = function(elem, type, fn) {
  * @private
  */
 function _handleMultipleEvents(fn, elem, type, callback) {
-  VjsLib.arr.forEach(type, function(type) {
+  Lib.arr.forEach(type, function(type) {
     fn(elem, type, callback); //Call the event method for each one of the types
   });
 }

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -5,7 +5,8 @@
  */
 
 import window from 'global/window';
-let JSON = window.JSON;
+// Changing 'JSON' throws jshint errors
+var json = window.JSON;
 
 /**
  * Javascript JSON implementation
@@ -16,8 +17,8 @@ let JSON = window.JSON;
  * @namespace
  * @private
  */
-if (!(typeof JSON !== 'undefined' && typeof JSON.parse === 'function')) {
-  JSON = {};
+if (!(typeof json !== 'undefined' && typeof json.parse === 'function')) {
+  json = {};
 
   var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
 
@@ -29,7 +30,7 @@ if (!(typeof JSON !== 'undefined' && typeof JSON.parse === 'function')) {
    * @param {Function=} [reviver] Optional function that can transform the results
    * @return {Object|Array} The parsed JSON
    */
-  JSON.parse = function (text, reviver) {
+   json.parse = function (text, reviver) {
     var j;
 
     function walk(holder, key) {
@@ -71,4 +72,4 @@ if (!(typeof JSON !== 'undefined' && typeof JSON.parse === 'function')) {
   };
 }
 
-export default JSON;
+export default json;

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -11,7 +11,7 @@ let hasOwnProp = Object.prototype.hasOwnProperty;
  * @return {Element}
  * @private
  */
-let createEl = function(tagName, properties){
+var createEl = function(tagName, properties){
   tagName = tagName || 'div';
   properties = properties || {};
 
@@ -259,7 +259,7 @@ var hasData = function(el){
  * @param  {Element} el Remove data for an element
  * @private
  */
-let removeData = function(el){
+var removeData = function(el){
   var id = el[expando];
   if (!id) { return; }
   // Remove all stored data
@@ -812,7 +812,7 @@ var findPosition = function(el) {
  * @type {Object}
  * @private
  */
-let arr = {};
+var arr = {};
 
 /*
  * Loops through an array and runs a function for each item inside it.

--- a/src/js/media-error.js
+++ b/src/js/media-error.js
@@ -1,4 +1,4 @@
-import * as VjsLib from './lib';
+import * as Lib from './lib';
 
 /**
  * Custom MediaError to mimic the HTML5 MediaError
@@ -11,7 +11,7 @@ let MediaError = function(code){
     // default code is zero, so this is a custom error
     this.message = code;
   } else if (typeof code === 'object') { // object
-    VjsLib.obj.merge(this, code);
+    Lib.obj.merge(this, code);
   }
 
   if (!this.message) {

--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -5,10 +5,11 @@
  */
 
 import MediaTechController from './media';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 import FlashRtmpDecorator from './flash-rtmp';
 import Component from '../component';
 import window from 'global/window';
+let navigator = window.navigator;
 
 /**
  * Flash Media Controller - Wrapper for fallback SWF API
@@ -29,7 +30,7 @@ var Flash = MediaTechController.extend({
     let parentEl = options['parentEl'];
 
     // Create a temporary element to be replaced by swf object
-    let placeHolder = this.el_ = VjsLib.createEl('div', { id: player.id() + '_temp_flash' });
+    let placeHolder = this.el_ = Lib.createEl('div', { id: player.id() + '_temp_flash' });
 
     // Generate ID for swf object
     let objId = player.id()+'_flash_api';
@@ -40,7 +41,7 @@ var Flash = MediaTechController.extend({
     let playerOptions = player.options_;
 
     // Merge default flashvars with ones passed in to init
-    let flashVars = VjsLib.obj.merge({
+    let flashVars = Lib.obj.merge({
 
       // SWF Callback Functions
       'readyFunction': 'videojs.Flash.onReady',
@@ -56,13 +57,13 @@ var Flash = MediaTechController.extend({
     }, options['flashVars']);
 
     // Merge default parames with ones passed in
-    let params = VjsLib.obj.merge({
+    let params = Lib.obj.merge({
       'wmode': 'opaque', // Opaque is needed to overlay controls, but can affect playback performance
       'bgcolor': '#000000' // Using bgcolor prevents a white flash when the object is loading
     }, options['params']);
 
     // Merge default attributes with ones passed in
-    let attributes = VjsLib.obj.merge({
+    let attributes = Lib.obj.merge({
       'id': objId,
       'name': objId, // Both ID and Name needed or swf to identify itself
       'class': 'vjs-tech'
@@ -76,7 +77,7 @@ var Flash = MediaTechController.extend({
     }
 
     // Add placeholder to player div
-    VjsLib.insertFirst(placeHolder, parentEl);
+    Lib.insertFirst(placeHolder, parentEl);
 
     // Having issues with Flash reloading on certain page actions (hide/resize/fullscreen) in certain browsers
     // This allows resetting the playhead when we catch the reload
@@ -90,7 +91,7 @@ var Flash = MediaTechController.extend({
 
     // firefox doesn't bubble mousemove events to parent. videojs/video-js-swf#37
     // bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=836786
-    if (VjsLib.IS_FIREFOX) {
+    if (Lib.IS_FIREFOX) {
       this.ready(function(){
         this.on('mousemove', function(){
           // since it's a custom event, don't bubble higher than the player
@@ -132,7 +133,7 @@ Flash.prototype.src = function(src){
 
 Flash.prototype.setSrc = function(src){
   // Make sure source URL is absolute.
-  src = VjsLib.getAbsoluteURL(src);
+  src = Lib.getAbsoluteURL(src);
   this.el_.vjs_src(src);
 
   // Currently the SWF doesn't autoplay if you load a source later.
@@ -178,7 +179,7 @@ Flash.prototype['setPoster'] = function(){
 };
 
 Flash.prototype.buffered = function(){
-  return VjsLib.createTimeRange(0, this.el_.vjs_getProperty('buffered'));
+  return Lib.createTimeRange(0, this.el_.vjs_getProperty('buffered'));
 };
 
 Flash.prototype.supportsFullScreen = function(){
@@ -281,7 +282,7 @@ Flash.formats = {
 };
 
 Flash['onReady'] = function(currSwf){
-  let el = VjsLib.el(currSwf);
+  let el = Lib.el(currSwf);
 
   // get player from the player div property
   const player = el && el.parentNode && el.parentNode['player'];
@@ -318,13 +319,13 @@ Flash['checkReady'] = function(tech){
 
 // Trigger events from the swf on the player
 Flash['onEvent'] = function(swfID, eventName){
-  let player = VjsLib.el(swfID)['player'];
+  let player = Lib.el(swfID)['player'];
   player.trigger(eventName);
 };
 
 // Log errors from the swf
 Flash['onError'] = function(swfID, err){
-  const player = VjsLib.el(swfID)['player'];
+  const player = Lib.el(swfID)['player'];
   const msg = 'FLASH: '+err;
 
   if (err == 'srcnotfound') {
@@ -360,7 +361,7 @@ Flash.embed = function(swf, placeHolder, flashVars, params, attributes){
   const code = Flash.getEmbedCode(swf, flashVars, params, attributes);
 
   // Get element by embedding code and retrieving created element
-  const obj = VjsLib.createEl('div', { innerHTML: code }).childNodes[0];
+  const obj = Lib.createEl('div', { innerHTML: code }).childNodes[0];
 
   const par = placeHolder.parentNode;
 
@@ -377,13 +378,13 @@ Flash.getEmbedCode = function(swf, flashVars, params, attributes){
 
   // Convert flash vars to string
   if (flashVars) {
-    VjsLib.obj.each(flashVars, function(key, val){
+    Lib.obj.each(flashVars, function(key, val){
       flashVarsString += (key + '=' + val + '&amp;');
     });
   }
 
   // Add swf, flashVars, and other default params
-  params = VjsLib.obj.merge({
+  params = Lib.obj.merge({
     'movie': swf,
     'flashvars': flashVarsString,
     'allowScriptAccess': 'always', // Required to talk to swf
@@ -391,11 +392,11 @@ Flash.getEmbedCode = function(swf, flashVars, params, attributes){
   }, params);
 
   // Create param tags string
-  VjsLib.obj.each(params, function(key, val){
+  Lib.obj.each(params, function(key, val){
     paramsString += '<param name="'+key+'" value="'+val+'" />';
   });
 
-  attributes = VjsLib.obj.merge({
+  attributes = Lib.obj.merge({
     // Add swf to attributes (need both for IE and Others to work)
     'data': swf,
 
@@ -406,7 +407,7 @@ Flash.getEmbedCode = function(swf, flashVars, params, attributes){
   }, attributes);
 
   // Create Attributes string
-  VjsLib.obj.each(attributes, function(key, val){
+  Lib.obj.each(attributes, function(key, val){
     attrsString += (key + '="' + val + '" ');
   });
 

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -4,7 +4,7 @@
 
 import MediaTechController from './media';
 import Component from '../component';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 import * as VjsUtil from '../util';
 import document from 'global/document';
 
@@ -64,14 +64,14 @@ var Html5 = MediaTechController.extend({
     }
 
     if (this['featuresNativeTextTracks']) {
-      this.on('loadstart', VjsLib.bind(this, this.hideCaptions));
+      this.on('loadstart', Lib.bind(this, this.hideCaptions));
     }
 
     // Determine if native controls should be used
     // Our goal should be to get the custom controls on mobile solid everywhere
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
-    if (VjsLib.TOUCH_ENABLED && player.options()['nativeControlsForTouch'] === true) {
+    if (Lib.TOUCH_ENABLED && player.options()['nativeControlsForTouch'] === true) {
       this.useNativeControls();
     }
 
@@ -113,16 +113,16 @@ Html5.prototype.createEl = function(){
       el = clone;
       player.tag = null;
     } else {
-      el = VjsLib.createEl('video');
+      el = Lib.createEl('video');
 
       // determine if native controls should be used
       let attributes = VjsUtil.mergeOptions({}, player.tagAttributes);
-      if (!VjsLib.TOUCH_ENABLED || player.options()['nativeControlsForTouch'] !== true) {
+      if (!Lib.TOUCH_ENABLED || player.options()['nativeControlsForTouch'] !== true) {
         delete attributes.controls;
       }
 
-      VjsLib.setElementAttributes(el,
-        VjsLib.obj.merge(attributes, {
+      Lib.setElementAttributes(el,
+        Lib.obj.merge(attributes, {
           id: player.id() + '_html5_api',
           class: 'vjs-tech'
         })
@@ -146,7 +146,7 @@ Html5.prototype.createEl = function(){
       }
     }
 
-    VjsLib.insertFirst(el, player.el());
+    Lib.insertFirst(el, player.el());
   }
 
   // Update specific tag settings, in case they were overridden
@@ -157,7 +157,7 @@ Html5.prototype.createEl = function(){
     if (typeof player.options_[attr] !== 'undefined') {
       overwriteAttrs[attr] = player.options_[attr];
     }
-    VjsLib.setElementAttributes(el, overwriteAttrs);
+    Lib.setElementAttributes(el, overwriteAttrs);
   }
 
   return el;
@@ -247,7 +247,7 @@ Html5.prototype.setCurrentTime = function(seconds){
   try {
     this.el_.currentTime = seconds;
   } catch(e) {
-    VjsLib.log(e, 'Video is not ready. (Video.js)');
+    Lib.log(e, 'Video is not ready. (Video.js)');
     // this.warning(VideoJS.warnings.videoNotReady);
   }
 };
@@ -267,7 +267,7 @@ Html5.prototype.supportsFullScreen = function(){
   if (typeof this.el_.webkitEnterFullScreen == 'function') {
 
     // Seems to be broken in Chromium/Chrome && Safari in Leopard
-    if (/Android/.test(VjsLib.USER_AGENT) || !/Chrome|Mac OS X 10.5/.test(VjsLib.USER_AGENT)) {
+    if (/Android/.test(Lib.USER_AGENT) || !/Chrome|Mac OS X 10.5/.test(Lib.USER_AGENT)) {
       return true;
     }
   }
@@ -448,12 +448,12 @@ Html5.prototype.removeRemoteTextTrack = function(track) {
 Html5.isSupported = function(){
   // IE9 with no Media Player is a LIAR! (#984)
   try {
-    VjsLib.TEST_VID['volume'] = 0.5;
+    Lib.TEST_VID['volume'] = 0.5;
   } catch (e) {
     return false;
   }
 
-  return !!VjsLib.TEST_VID.canPlayType;
+  return !!Lib.TEST_VID.canPlayType;
 };
 
 // Add Source Handler pattern functions to this tech
@@ -479,7 +479,7 @@ Html5.nativeSourceHandler.canHandleSource = function(source){
     // IE9 on Windows 7 without MediaPlayer throws an error here
     // https://github.com/videojs/video.js/issues/519
     try {
-      return VjsLib.TEST_VID.canPlayType(type);
+      return Lib.TEST_VID.canPlayType(type);
     } catch(e) {
       return '';
     }
@@ -526,9 +526,9 @@ Html5.registerSourceHandler(Html5.nativeSourceHandler);
  * @return {Boolean}
  */
 Html5.canControlVolume = function(){
-  var volume =  VjsLib.TEST_VID.volume;
-  VjsLib.TEST_VID.volume = (volume / 2) + 0.1;
-  return volume !== VjsLib.TEST_VID.volume;
+  var volume =  Lib.TEST_VID.volume;
+  Lib.TEST_VID.volume = (volume / 2) + 0.1;
+  return volume !== Lib.TEST_VID.volume;
 };
 
 /**
@@ -536,9 +536,9 @@ Html5.canControlVolume = function(){
  * @return {[type]} [description]
  */
 Html5.canControlPlaybackRate = function(){
-  var playbackRate =  VjsLib.TEST_VID.playbackRate;
-  VjsLib.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;
-  return playbackRate !== VjsLib.TEST_VID.playbackRate;
+  var playbackRate =  Lib.TEST_VID.playbackRate;
+  Lib.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;
+  return playbackRate !== Lib.TEST_VID.playbackRate;
 };
 
 /**
@@ -553,11 +553,11 @@ Html5.supportsNativeTextTracks = function() {
   // Browsers with numeric modes include IE10 and older (<=2013) samsung android models.
   // Firefox isn't playing nice either with modifying the mode
   // TODO: Investigate firefox: https://github.com/videojs/video.js/issues/1862
-  supportsTextTracks = !!VjsLib.TEST_VID.textTracks;
-  if (supportsTextTracks && VjsLib.TEST_VID.textTracks.length > 0) {
-    supportsTextTracks = typeof VjsLib.TEST_VID.textTracks[0]['mode'] !== 'number';
+  supportsTextTracks = !!Lib.TEST_VID.textTracks;
+  if (supportsTextTracks && Lib.TEST_VID.textTracks.length > 0) {
+    supportsTextTracks = typeof Lib.TEST_VID.textTracks[0]['mode'] !== 'number';
   }
-  if (supportsTextTracks && VjsLib.IS_FIREFOX) {
+  if (supportsTextTracks && Lib.IS_FIREFOX) {
     supportsTextTracks = false;
   }
 
@@ -581,7 +581,7 @@ Html5.prototype['featuresPlaybackRate'] = Html5.canControlPlaybackRate();
  * In iOS, if you move a video element in the DOM, it breaks video playback.
  * @type {Boolean}
  */
-Html5.prototype['movingMediaElementInDOM'] = !VjsLib.IS_IOS;
+Html5.prototype['movingMediaElementInDOM'] = !Lib.IS_IOS;
 
 /**
  * Set the the tech's fullscreen resize support status.
@@ -609,12 +609,12 @@ const mp4RE = /^video\/mp4/i;
 
 Html5.patchCanPlayType = function() {
   // Android 4.0 and above can play HLS to some extent but it reports being unable to do so
-  if (VjsLib.ANDROID_VERSION >= 4.0) {
+  if (Lib.ANDROID_VERSION >= 4.0) {
     if (!canPlayType) {
-      canPlayType = VjsLib.TEST_VID.constructor.prototype.canPlayType;
+      canPlayType = Lib.TEST_VID.constructor.prototype.canPlayType;
     }
 
-    VjsLib.TEST_VID.constructor.prototype.canPlayType = function(type) {
+    Lib.TEST_VID.constructor.prototype.canPlayType = function(type) {
       if (type && mpegurlRE.test(type)) {
         return 'maybe';
       }
@@ -623,12 +623,12 @@ Html5.patchCanPlayType = function() {
   }
 
   // Override Android 2.2 and less canPlayType method which is broken
-  if (VjsLib.IS_OLD_ANDROID) {
+  if (Lib.IS_OLD_ANDROID) {
     if (!canPlayType) {
-      canPlayType = VjsLib.TEST_VID.constructor.prototype.canPlayType;
+      canPlayType = Lib.TEST_VID.constructor.prototype.canPlayType;
     }
 
-    VjsLib.TEST_VID.constructor.prototype.canPlayType = function(type){
+    Lib.TEST_VID.constructor.prototype.canPlayType = function(type){
       if (type && mp4RE.test(type)) {
         return 'maybe';
       }
@@ -638,8 +638,8 @@ Html5.patchCanPlayType = function() {
 };
 
 Html5.unpatchCanPlayType = function() {
-  var r = VjsLib.TEST_VID.constructor.prototype.canPlayType;
-  VjsLib.TEST_VID.constructor.prototype.canPlayType = canPlayType;
+  var r = Lib.TEST_VID.constructor.prototype.canPlayType;
+  Lib.TEST_VID.constructor.prototype.canPlayType = canPlayType;
   canPlayType = null;
   return r;
 };

--- a/src/js/media/loader.js
+++ b/src/js/media/loader.js
@@ -1,5 +1,5 @@
 import Component from '../component';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 import window from 'global/window';
 
 /**
@@ -17,7 +17,7 @@ let MediaLoader = Component.extend({
     // load the first supported playback technology.
     if (!player.options_['sources'] || player.options_['sources'].length === 0) {
       for (let i=0, j=player.options_['techOrder']; i<j.length; i++) {
-        let techName = VjsLib.capitalize(j[i]);
+        let techName = Lib.capitalize(j[i]);
         let tech = Component.getComponent(techName);
 
         // Check if the browser supports this technology

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -6,7 +6,7 @@
 import Component from '../component';
 import TextTrack from '../tracks/text-track';
 import TextTrackList from '../tracks/text-track-list';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 import window from 'global/window';
 import document from 'global/document';
 
@@ -286,7 +286,7 @@ MediaTechController.prototype.initTextTrackListeners = function() {
   tracks.addEventListener('removetrack', textTrackListChanges);
   tracks.addEventListener('addtrack', textTrackListChanges);
 
-  this.on('dispose', VjsLib.bind(this, function() {
+  this.on('dispose', Lib.bind(this, function() {
     tracks.removeEventListener('removetrack', textTrackListChanges);
     tracks.removeEventListener('addtrack', textTrackListChanges);
   }));
@@ -314,16 +314,16 @@ MediaTechController.prototype.emulateTextTracks = function() {
 
     for (let i = 0; i < this.length; i++) {
       let track = this[i];
-      track.removeEventListener('cuechange', VjsLib.bind(textTrackDisplay, textTrackDisplay.updateDisplay));
+      track.removeEventListener('cuechange', Lib.bind(textTrackDisplay, textTrackDisplay.updateDisplay));
       if (track.mode === 'showing') {
-        track.addEventListener('cuechange', VjsLib.bind(textTrackDisplay, textTrackDisplay.updateDisplay));
+        track.addEventListener('cuechange', Lib.bind(textTrackDisplay, textTrackDisplay.updateDisplay));
       }
     }
   };
 
   tracks.addEventListener('change', textTracksChanges);
 
-  this.on('dispose', VjsLib.bind(this, function() {
+  this.on('dispose', Lib.bind(this, function() {
     tracks.removeEventListener('change', textTracksChanges);
   }));
 };
@@ -498,7 +498,7 @@ MediaTechController.withSourceHandlers = function(Tech){
       if (Tech.nativeSourceHandler) {
         sh = Tech.nativeSourceHandler;
       } else {
-        VjsLib.log.error('No source hander found for the current source.');
+        Lib.log.error('No source hander found for the current source.');
       }
     }
 

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -1,7 +1,7 @@
 import Button from './button';
 import Component from './component';
-import * as VjsLib from './lib';
-import * as VjsEvents from './events';
+import * as Lib from './lib';
+import * as Events from './events';
 
 /* Menu
 ================================================================================ */
@@ -22,7 +22,7 @@ let Menu = Component.extend();
  */
 Menu.prototype.addItem = function(component){
   this.addChild(component);
-  component.on('click', VjsLib.bind(this, function(){
+  component.on('click', Lib.bind(this, function(){
     this.unlockShowing();
   }));
 };
@@ -30,7 +30,7 @@ Menu.prototype.addItem = function(component){
 /** @inheritDoc */
 Menu.prototype.createEl = function(){
   let contentElType = this.options().contentElType || 'ul';
-  this.contentEl_ = VjsLib.createEl(contentElType, {
+  this.contentEl_ = Lib.createEl(contentElType, {
     className: 'vjs-menu-content'
   });
   var el = Component.prototype.createEl.call(this, 'div', {
@@ -41,7 +41,7 @@ Menu.prototype.createEl = function(){
 
   // Prevent clicks from bubbling up. Needed for Menu Buttons,
   // where a click on the parent is significant
-  VjsEvents.on(el, 'click', function(event){
+  Events.on(el, 'click', function(event){
     event.preventDefault();
     event.stopImmediatePropagation();
   });
@@ -67,7 +67,7 @@ var MenuItem = Button.extend({
 
 /** @inheritDoc */
 MenuItem.prototype.createEl = function(type, props){
-  return Button.prototype.createEl.call(this, 'li', VjsLib.obj.merge({
+  return Button.prototype.createEl.call(this, 'li', Lib.obj.merge({
     className: 'vjs-menu-item',
     innerHTML: this.localize(this.options_['label'])
   }, props));
@@ -101,7 +101,7 @@ MenuItem.prototype.selected = function(selected){
  * @param {Object=} options
  * @constructor
  */
-let MenuButton = Button.extend({
+var MenuButton = Button.extend({
   /** @constructor */
   init: function(player, options){
     Button.call(this, player, options);
@@ -143,9 +143,9 @@ MenuButton.prototype.createMenu = function(){
 
   // Add a title list item to the top
   if (this.options().title) {
-    menu.contentEl().appendChild(VjsLib.createEl('li', {
+    menu.contentEl().appendChild(Lib.createEl('li', {
       className: 'vjs-menu-title',
-      innerHTML: VjsLib.capitalize(this.options().title),
+      innerHTML: Lib.capitalize(this.options().title),
       tabindex: -1
     }));
   }
@@ -184,7 +184,7 @@ MenuButton.prototype.onClick = function(){
   // When you click the button it adds focus, which will show the menu indefinitely.
   // So we'll remove focus when the mouse leaves the button.
   // Focus is needed for tab navigation.
-  this.one('mouseout', VjsLib.bind(this, function(){
+  this.one('mouseout', Lib.bind(this, function(){
     this.menu.unlockShowing();
     this.el_.blur();
   }));

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,3 +1,7 @@
+import document from 'global/document';
+import window from 'global/window';
+let navigator = window.navigator;
+
 /**
  * Global Player instance options, surfaced from vjs.Player.prototype.options_
  * vjs.options = vjs.Player.prototype.options_

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1,6 +1,6 @@
 import Component from './component.js';
-import * as VjsLib from './lib.js';
-import * as VjsEvents from './events.js';
+import * as Lib from './lib.js';
+import * as Events from './events.js';
 import FullscreenApi from './fullscreen-api.js';
 import MediaError from './media-error.js';
 import options from './options.js';
@@ -55,17 +55,17 @@ let Player = Component.extend({
     this.tag = tag; // Store the original tag used to set options
 
     // Make sure tag ID exists
-    tag.id = tag.id || 'vjs_video_' + VjsLib.guid++;
+    tag.id = tag.id || 'vjs_video_' + Lib.guid++;
 
     // Store the tag attributes used to restore html5 element
-    this.tagAttributes = tag && VjsLib.getElementAttributes(tag);
+    this.tagAttributes = tag && Lib.getElementAttributes(tag);
 
     // Set Options
     // The options argument overrides options set in the video tag
     // which overrides globally set options.
     // This latter part coincides with the load order
     // (tag must exist before Player)
-    options = VjsLib.obj.merge(this.getTagSettings(tag), options);
+    options = Lib.obj.merge(this.getTagSettings(tag), options);
 
     // Update Current Language
     this.language_ = options['language'] || options['language'];
@@ -120,7 +120,7 @@ let Player = Component.extend({
     Player.players[this.id_] = this;
 
     if (options['plugins']) {
-      VjsLib.obj.each(options['plugins'], function(key, val){
+      Lib.obj.each(options['plugins'], function(key, val){
         this[key](val);
       }, this);
     }
@@ -213,17 +213,17 @@ Player.prototype.getTagSettings = function(tag){
     'tracks': []
   };
 
-  const tagOptions = VjsLib.getElementAttributes(tag);
+  const tagOptions = Lib.getElementAttributes(tag);
   const dataSetup = tagOptions['data-setup'];
 
   // Check if data-setup attr exists.
   if (dataSetup !== null){
     // Parse options JSON
     // If empty string, make it a parsable json object.
-    VjsLib.obj.merge(tagOptions, JSON.parse(dataSetup || '{}'));
+    Lib.obj.merge(tagOptions, JSON.parse(dataSetup || '{}'));
   }
 
-  VjsLib.obj.merge(baseOptions, tagOptions);
+  Lib.obj.merge(baseOptions, tagOptions);
 
   // Get tag children settings
   if (tag.hasChildNodes()) {
@@ -234,9 +234,9 @@ Player.prototype.getTagSettings = function(tag){
       // Change case needed: http://ejohn.org/blog/nodename-case-sensitivity/
       const childName = child.nodeName.toLowerCase();
       if (childName === 'source') {
-        baseOptions['sources'].push(VjsLib.getElementAttributes(child));
+        baseOptions['sources'].push(Lib.getElementAttributes(child));
       } else if (childName === 'track') {
-        baseOptions['tracks'].push(VjsLib.getElementAttributes(child));
+        baseOptions['tracks'].push(Lib.getElementAttributes(child));
       }
     }
   }
@@ -254,8 +254,8 @@ Player.prototype.createEl = function(){
 
   // Copy over all the attributes from the tag, including ID and class
   // ID will now reference player box, not the video tag
-  const attrs = VjsLib.getElementAttributes(tag);
-  VjsLib.obj.each(attrs, function(attr) {
+  const attrs = Lib.getElementAttributes(tag);
+  Lib.obj.each(attrs, function(attr) {
     // workaround so we don't totally break IE7
     // http://stackoverflow.com/questions/3653444/css-styles-not-applied-on-dynamic-elements-in-internet-explorer-7
     if (attr == 'class') {
@@ -289,7 +289,7 @@ Player.prototype.createEl = function(){
   if (tag.parentNode) {
     tag.parentNode.insertBefore(el, tag);
   }
-  VjsLib.insertFirst(tag, el); // Breaks iPhone, fixed in HTML5 setup.
+  Lib.insertFirst(tag, el); // Breaks iPhone, fixed in HTML5 setup.
 
   // The event listeners need to be added before the children are added
   // in the component init because the tech (loaded with mediaLoader) may
@@ -341,7 +341,7 @@ Player.prototype.loadTech = function(techName, source){
   };
 
   // Grab tech-specific options from player options and add source and parent element to use.
-  var techOptions = VjsLib.obj.merge({ 'source': source, 'parentEl': this.el_ }, this.options_[techName.toLowerCase()]);
+  var techOptions = Lib.obj.merge({ 'source': source, 'parentEl': this.el_ }, this.options_[techName.toLowerCase()]);
 
   if (source) {
     this.currentType_ = source.type;
@@ -638,7 +638,7 @@ Player.prototype.techCall = function(method, arg){
     try {
       this.tech[method](arg);
     } catch(e) {
-      VjsLib.log(e);
+      Lib.log(e);
       throw e;
     }
   }
@@ -656,14 +656,14 @@ Player.prototype.techGet = function(method){
     } catch(e) {
       // When building additional tech libs, an expected method may not be defined yet
       if (this.tech[method] === undefined) {
-        VjsLib.log('Video.js: ' + method + ' method not defined for '+this.techName+' playback technology.', e);
+        Lib.log('Video.js: ' + method + ' method not defined for '+this.techName+' playback technology.', e);
       } else {
         // When a method isn't available on the object it throws a TypeError
         if (e.name == 'TypeError') {
-          VjsLib.log('Video.js: ' + method + ' unavailable on '+this.techName+' playback technology element.', e);
+          Lib.log('Video.js: ' + method + ' unavailable on '+this.techName+' playback technology element.', e);
           this.tech.isReady_ = false;
         } else {
-          VjsLib.log(e);
+          Lib.log(e);
         }
       }
       throw e;
@@ -807,7 +807,7 @@ Player.prototype.buffered = function(){
   var buffered = this.techGet('buffered');
 
   if (!buffered || !buffered.length) {
-    buffered = VjsLib.createTimeRange(0,0);
+    buffered = Lib.createTimeRange(0,0);
   }
 
   return buffered;
@@ -888,7 +888,7 @@ Player.prototype.volume = function(percentAsDecimal){
     vol = Math.max(0, Math.min(1, parseFloat(percentAsDecimal))); // Force value to between 0 and 1
     this.cache_.volume = vol;
     this.techCall('setVolume', vol);
-    VjsLib.setLocalStorage('volume', vol);
+    Lib.setLocalStorage('volume', vol);
     return this;
   }
 
@@ -962,7 +962,7 @@ Player.prototype.isFullscreen = function(isFS){
  * @deprecated for lowercase 's' version
  */
 Player.prototype.isFullScreen = function(isFS){
-  VjsLib.log.warn('player.isFullScreen() has been deprecated, use player.isFullscreen() with a lowercase "s")');
+  Lib.log.warn('player.isFullScreen() has been deprecated, use player.isFullscreen() with a lowercase "s")');
   return this.isFullscreen(isFS);
 };
 
@@ -994,12 +994,12 @@ Player.prototype.requestFullscreen = function(){
     // when canceling fullscreen. Otherwise if there's multiple
     // players on a page, they would all be reacting to the same fullscreen
     // events
-    VjsEvents.on(document, fsApi['fullscreenchange'], VjsLib.bind(this, function documentFullscreenChange(e){
+    Events.on(document, fsApi['fullscreenchange'], Lib.bind(this, function documentFullscreenChange(e){
       this.isFullscreen(document[fsApi.fullscreenElement]);
 
       // If cancelling fullscreen, remove event listener.
       if (this.isFullscreen() === false) {
-        VjsEvents.off(document, fsApi['fullscreenchange'], documentFullscreenChange);
+        Events.off(document, fsApi['fullscreenchange'], documentFullscreenChange);
       }
 
       this.trigger('fullscreenchange');
@@ -1026,7 +1026,7 @@ Player.prototype.requestFullscreen = function(){
  * @deprecated for lower case 's' version
  */
 Player.prototype.requestFullScreen = function(){
-  VjsLib.log.warn('player.requestFullScreen() has been deprecated, use player.requestFullscreen() with a lowercase "s")');
+  Lib.log.warn('player.requestFullScreen() has been deprecated, use player.requestFullscreen() with a lowercase "s")');
   return this.requestFullscreen();
 };
 
@@ -1059,7 +1059,7 @@ Player.prototype.exitFullscreen = function(){
  * @deprecated for exitFullscreen
  */
 Player.prototype.cancelFullScreen = function(){
-  VjsLib.log.warn('player.cancelFullScreen() has been deprecated, use player.exitFullscreen()');
+  Lib.log.warn('player.cancelFullScreen() has been deprecated, use player.exitFullscreen()');
   return this.exitFullscreen();
 };
 
@@ -1071,13 +1071,13 @@ Player.prototype.enterFullWindow = function(){
   this.docOrigOverflow = document.documentElement.style.overflow;
 
   // Add listener for esc key to exit fullscreen
-  VjsEvents.on(document, 'keydown', VjsLib.bind(this, this.fullWindowOnEscKey));
+  Events.on(document, 'keydown', Lib.bind(this, this.fullWindowOnEscKey));
 
   // Hide any scroll bars
   document.documentElement.style.overflow = 'hidden';
 
   // Apply fullscreen styles
-  VjsLib.addClass(document.body, 'vjs-full-window');
+  Lib.addClass(document.body, 'vjs-full-window');
 
   this.trigger('enterFullWindow');
 };
@@ -1094,13 +1094,13 @@ Player.prototype.fullWindowOnEscKey = function(event){
 
 Player.prototype.exitFullWindow = function(){
   this.isFullWindow = false;
-  VjsEvents.off(document, 'keydown', this.fullWindowOnEscKey);
+  Events.off(document, 'keydown', this.fullWindowOnEscKey);
 
   // Unhide scroll bars.
   document.documentElement.style.overflow = this.docOrigOverflow;
 
   // Remove fullscreen styles
-  VjsLib.removeClass(document.body, 'vjs-full-window');
+  Lib.removeClass(document.body, 'vjs-full-window');
 
   // Resize the box, controller, and poster to original sizes
   // this.positionAll();
@@ -1110,12 +1110,12 @@ Player.prototype.exitFullWindow = function(){
 Player.prototype.selectSource = function(sources){
   // Loop through each playback technology in the options order
   for (var i=0,j=this.options_['techOrder'];i<j.length;i++) {
-    let techName = VjsLib.capitalize(j[i]);
+    let techName = Lib.capitalize(j[i]);
     let tech = Component.getComponent(techName);
 
     // Check if the current tech is defined before continuing
     if (!tech) {
-      VjsLib.log.error('The "' + techName + '" tech is undefined. Skipped browser support check for that tech.');
+      Lib.log.error('The "' + techName + '" tech is undefined. Skipped browser support check for that tech.');
       continue;
     }
 
@@ -1176,7 +1176,7 @@ Player.prototype.src = function(source){
   }
 
   // case: Array of source objects to choose from and pick the best to play
-  if (VjsLib.obj.isArray(source)) {
+  if (Lib.obj.isArray(source)) {
     this.sourceList_(source);
 
   // case: URL String (http://myvideo...)
@@ -1490,7 +1490,7 @@ Player.prototype.error = function(err){
 
   // log the name of the error type and any message
   // ie8 just logs "[object object]" if you just log the error object
-  VjsLib.log.error('(CODE:'+this.error_.code+' '+MediaError.errorTypes[this.error_.code]+')', this.error_.message, this.error_);
+  Lib.log.error('(CODE:'+this.error_.code+' '+MediaError.errorTypes[this.error_.code]+')', this.error_.message, this.error_);
 
   return this;
 };
@@ -1560,7 +1560,7 @@ Player.prototype.userActive = function(bool){
 Player.prototype.listenForUserActivity = function(){
   let mouseInProgress, lastMoveX, lastMoveY;
 
-  let onActivity = VjsLib.bind(this, this.reportUserActivity);
+  let onActivity = Lib.bind(this, this.reportUserActivity);
 
   let onMouseMove = function(e) {
     // #1068 - Prevent mousemove spamming

--- a/src/js/poster.js
+++ b/src/js/poster.js
@@ -1,5 +1,5 @@
 import Button from './button';
-import * as VjsLib from './lib';
+import * as Lib from './lib';
 import Component from './component';
 
 /* Poster Image
@@ -17,7 +17,7 @@ let PosterImage = Button.extend({
     Button.call(this, player, options);
 
     this.update();
-    player.on('posterchange', VjsLib.bind(this, this.update));
+    player.on('posterchange', Lib.bind(this, this.update));
   }
 });
 
@@ -36,7 +36,7 @@ PosterImage.prototype.dispose = function(){
  * @return {Element}
  */
 PosterImage.prototype.createEl = function(){
-  let el = VjsLib.createEl('div', {
+  let el = Lib.createEl('div', {
     className: 'vjs-poster',
 
     // Don't want poster to be tabbable.
@@ -47,8 +47,8 @@ PosterImage.prototype.createEl = function(){
   // ratio, use a div with `background-size` when available. For browsers that
   // do not support `background-size` (e.g. IE8), fall back on using a regular
   // img element.
-  if (!VjsLib.BACKGROUND_SIZE_SUPPORTED) {
-    this.fallbackImg_ = VjsLib.createEl('img');
+  if (!Lib.BACKGROUND_SIZE_SUPPORTED) {
+    this.fallbackImg_ = Lib.createEl('img');
     el.appendChild(this.fallbackImg_);
   }
 

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -1,5 +1,5 @@
 import JSON from './json';
-import * as VjsEvents from './events';
+import * as Events from './events';
 import document from 'global/document';
 import window from 'global/window';
 
@@ -12,7 +12,7 @@ let videojs;
  */
 
 // Automatically set up any tags that have a data-setup attribute
-let autoSetup = function(){
+var autoSetup = function(){
   // One day, when we stop supporting IE8, go back to this, but in the meantime...*hack hack hack*
   // var vids = Array.prototype.slice.call(document.getElementsByTagName('video'));
   // var audios = Array.prototype.slice.call(document.getElementsByTagName('audio'));
@@ -78,7 +78,7 @@ var autoSetupTimeout = function(wait, vjs){
 if (document.readyState === 'complete') {
   _windowLoaded = true;
 } else {
-  VjsEvents.one(window, 'load', function(){
+  Events.one(window, 'load', function(){
     _windowLoaded = true;
   });
 }

--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -1,5 +1,5 @@
 import Component from './component';
-import * as VjsLib from './lib';
+import * as Lib from './lib';
 import document from 'global/document';
 
 /* Slider
@@ -40,7 +40,7 @@ Slider.prototype.createEl = function(type, props) {
   props = props || {};
   // Add the slider element class to all sub classes
   props.className = props.className + ' vjs-slider';
-  props = VjsLib.obj.merge({
+  props = Lib.obj.merge({
     'role': 'slider',
     'aria-valuenow': 0,
     'aria-valuemin': 0,
@@ -53,7 +53,7 @@ Slider.prototype.createEl = function(type, props) {
 
 Slider.prototype.onMouseDown = function(event){
   event.preventDefault();
-  VjsLib.blockTextSelection();
+  Lib.blockTextSelection();
   this.addClass('vjs-sliding');
 
   this.on(document, 'mousemove', this.onMouseMove);
@@ -68,7 +68,7 @@ Slider.prototype.onMouseDown = function(event){
 Slider.prototype.onMouseMove = function(){};
 
 Slider.prototype.onMouseUp = function() {
-  VjsLib.unblockTextSelection();
+  Lib.unblockTextSelection();
   this.removeClass('vjs-sliding');
 
   this.off(document, 'mousemove', this.onMouseMove);
@@ -106,7 +106,7 @@ Slider.prototype.update = function(){
   let barProgress = this.updateHandlePosition(progress);
 
   // Convert to a percentage for setting
-  let percentage = VjsLib.round(barProgress * 100, 2) + '%';
+  let percentage = Lib.round(barProgress * 100, 2) + '%';
 
   // Set the new bar width or height
   if (this.vertical()) {
@@ -149,7 +149,7 @@ Slider.prototype.updateHandlePosition = function(progress) {
   // The bar does reach the left side, so we need to account for this in the bar's width
   let barProgress = adjustedProgress + (handlePercent / 2);
 
-  let percentage = VjsLib.round(adjustedProgress * 100, 2) + '%';
+  let percentage = Lib.round(adjustedProgress * 100, 2) + '%';
 
   if (vertical) {
     handle.el().style.bottom = percentage;
@@ -162,7 +162,7 @@ Slider.prototype.updateHandlePosition = function(progress) {
 
 Slider.prototype.calculateDistance = function(event){
   let el = this.el_;
-  let box = VjsLib.findPosition(el);
+  let box = Lib.findPosition(el);
   let boxW = el.offsetWidth;
   let boxH = el.offsetHeight;
   let handle = this.handle;
@@ -262,7 +262,7 @@ Slider.prototype.vertical = function(bool) {
  * @param {Object=} options
  * @constructor
  */
-let SliderHandle = Component.extend();
+var SliderHandle = Component.extend();
 
 Component.registerComponent('Slider', Slider);
 
@@ -279,7 +279,7 @@ SliderHandle.prototype.createEl = function(type, props) {
   props = props || {};
   // Add the slider element class to all sub classes
   props.className = props.className + ' vjs-slider-handle';
-  props = VjsLib.obj.merge({
+  props = Lib.obj.merge({
     innerHTML: '<span class="vjs-control-text">'+this.defaultValue+'</span>'
   }, props);
 

--- a/src/js/tracks/text-track-controls.js
+++ b/src/js/tracks/text-track-controls.js
@@ -1,6 +1,7 @@
 import Component from '../component';
 import Menu, { MenuItem, MenuButton } from '../menu';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
+import document from 'global/document';
 import window from 'global/window';
 
 /* Text Track Display
@@ -12,24 +13,24 @@ import window from 'global/window';
  *
  * @constructor
  */
-let TextTrackDisplay = Component.extend({
+var TextTrackDisplay = Component.extend({
   /** @constructor */
   init: function(player, options, ready){
     Component.call(this, player, options, ready);
 
-    player.on('loadstart', VjsLib.bind(this, this.toggleDisplay));
+    player.on('loadstart', Lib.bind(this, this.toggleDisplay));
 
     // This used to be called during player init, but was causing an error
     // if a track should show by default and the display hadn't loaded yet.
     // Should probably be moved to an external track loader when we support
     // tracks that don't need a display.
-    player.ready(VjsLib.bind(this, function() {
+    player.ready(Lib.bind(this, function() {
       if (player.tech && player.tech['featuresNativeTextTracks']) {
         this.hide();
         return;
       }
 
-      player.on('fullscreenchange', VjsLib.bind(this, this.updateDisplay));
+      player.on('fullscreenchange', Lib.bind(this, this.updateDisplay));
 
       let tracks = player.options_['tracks'] || [];
       for (let i = 0; i < tracks.length; i++) {
@@ -186,7 +187,7 @@ TextTrackDisplay.prototype.updateForTrack = function(track) {
  *
  * @constructor
  */
-let TextTrackMenuItem = MenuItem.extend({
+var TextTrackMenuItem = MenuItem.extend({
   /** @constructor */
   init: function(player, options){
     let track = this.track = options['track'];
@@ -195,7 +196,7 @@ let TextTrackMenuItem = MenuItem.extend({
     let changeHandler;
 
     if (tracks) {
-      changeHandler = VjsLib.bind(this, function() {
+      changeHandler = Lib.bind(this, function() {
         let selected = this.track['mode'] === 'showing';
 
         if (this instanceof OffTextTrackMenuItem) {
@@ -281,7 +282,7 @@ TextTrackMenuItem.prototype.onClick = function(){
  *
  * @constructor
  */
-let OffTextTrackMenuItem = TextTrackMenuItem.extend({
+var OffTextTrackMenuItem = TextTrackMenuItem.extend({
   /** @constructor */
   init: function(player, options){
     // Create pseudo track info
@@ -326,7 +327,7 @@ CaptionSettingsMenuItem.prototype.onClick = function() {
  *
  * @constructor
  */
-let TextTrackButton = MenuButton.extend({
+var TextTrackButton = MenuButton.extend({
   /** @constructor */
   init: function(player, options){
     MenuButton.call(this, player, options);
@@ -341,7 +342,7 @@ let TextTrackButton = MenuButton.extend({
       return;
     }
 
-    let updateHandler = VjsLib.bind(this, this.update);
+    let updateHandler = Lib.bind(this, this.update);
     tracks.addEventListener('removetrack', updateHandler);
     tracks.addEventListener('addtrack', updateHandler);
 
@@ -390,7 +391,7 @@ TextTrackButton.prototype.createItems = function(){
  *
  * @constructor
  */
-let CaptionsButton = TextTrackButton.extend({
+var CaptionsButton = TextTrackButton.extend({
   /** @constructor */
   init: function(player, options, ready){
     TextTrackButton.call(this, player, options, ready);
@@ -425,7 +426,7 @@ CaptionsButton.prototype.update = function() {
  *
  * @constructor
  */
-let SubtitlesButton = TextTrackButton.extend({
+var SubtitlesButton = TextTrackButton.extend({
   /** @constructor */
   init: function(player, options, ready){
     TextTrackButton.call(this, player, options, ready);
@@ -446,7 +447,7 @@ SubtitlesButton.prototype.className = 'vjs-subtitles-button';
  *
  * @constructor
  */
-let ChaptersButton = TextTrackButton.extend({
+var ChaptersButton = TextTrackButton.extend({
   /** @constructor */
   init: function(player, options, ready){
     TextTrackButton.call(this, player, options, ready);
@@ -494,7 +495,7 @@ ChaptersButton.prototype.createMenu = function(){
         track['mode'] = 'hidden';
         /* jshint loopfunc:true */
         // TODO see if we can figure out a better way of doing this https://github.com/videojs/video.js/issues/1864
-        window.setTimeout(VjsLib.bind(this, function() {
+        window.setTimeout(Lib.bind(this, function() {
           this.createMenu();
         }), 100);
         /* jshint loopfunc:false */
@@ -508,9 +509,9 @@ ChaptersButton.prototype.createMenu = function(){
   let menu = this.menu;
   if (menu === undefined) {
     menu = new Menu(this.player_);
-    menu.contentEl().appendChild(VjsLib.createEl('li', {
+    menu.contentEl().appendChild(Lib.createEl('li', {
       className: 'vjs-menu-title',
-      innerHTML: VjsLib.capitalize(this.kind_),
+      innerHTML: Lib.capitalize(this.kind_),
       tabindex: -1
     }));
   }
@@ -544,7 +545,7 @@ ChaptersButton.prototype.createMenu = function(){
 /**
  * @constructor
  */
-let ChaptersTrackMenuItem = MenuItem.extend({
+var ChaptersTrackMenuItem = MenuItem.extend({
   /** @constructor */
   init: function(player, options){
     let track = this.track = options['track'];
@@ -556,7 +557,7 @@ let ChaptersTrackMenuItem = MenuItem.extend({
     options['selected'] = (cue['startTime'] <= currentTime && currentTime < cue['endTime']);
     MenuItem.call(this, player, options);
 
-    track.addEventListener('cuechange', VjsLib.bind(this, this.update));
+    track.addEventListener('cuechange', Lib.bind(this, this.update));
   }
 });
 

--- a/src/js/tracks/text-track-enums.js
+++ b/src/js/tracks/text-track-enums.js
@@ -3,7 +3,7 @@
  *
  * enum TextTrackMode { "disabled",  "hidden",  "showing" };
  */
-let TextTrackMode = {
+var TextTrackMode = {
   'disabled': 'disabled',
   'hidden': 'hidden',
   'showing': 'showing'
@@ -14,7 +14,7 @@ let TextTrackMode = {
  *
  * enum TextTrackKind { "subtitles",  "captions",  "descriptions",  "chapters",  "metadata" };
  */
-let TextTrackKind = {
+var TextTrackKind = {
   'subtitles': 'subtitles',
   'captions': 'captions',
   'descriptions': 'descriptions',

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -1,5 +1,5 @@
 import EventEmitter from '../event-emitter';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 import document from 'global/document';
 
 /*
@@ -18,7 +18,7 @@ import document from 'global/document';
 let TextTrackList = function(tracks) {
   let list = this;
 
-  if (VjsLib.IS_IE8) {
+  if (Lib.IS_IE8) {
     list = document.createElement('custom');
 
     for (let prop in TextTrackList.prototype) {
@@ -39,12 +39,12 @@ let TextTrackList = function(tracks) {
     list.addTrack_(tracks[i]);
   }
 
-  if (VjsLib.IS_IE8) {
+  if (Lib.IS_IE8) {
     return list;
   }
 };
 
-TextTrackList.prototype = VjsLib.obj.create(EventEmitter.prototype);
+TextTrackList.prototype = Lib.obj.create(EventEmitter.prototype);
 TextTrackList.prototype.constructor = TextTrackList;
 
 /*
@@ -73,7 +73,7 @@ TextTrackList.prototype.addTrack_ = function(track) {
     });
   }
 
-  track.addEventListener('modechange', VjsLib.bind(this, function() {
+  track.addEventListener('modechange', Lib.bind(this, function() {
     this.trigger('change');
   }));
   this.tracks_.push(track);

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -1,6 +1,6 @@
 import Component from '../component';
-import * as VjsLib from '../lib';
-import * as VjsEvents from '../events';
+import * as Lib from '../lib';
+import * as Events from '../events';
 import window from 'global/window';
 
 let TextTrackSettings = Component.extend({
@@ -8,12 +8,12 @@ let TextTrackSettings = Component.extend({
     Component.call(this, player, options);
     this.hide();
 
-    VjsEvents.on(this.el().querySelector('.vjs-done-button'), 'click', VjsLib.bind(this, function() {
+    Events.on(this.el().querySelector('.vjs-done-button'), 'click', Lib.bind(this, function() {
       this.saveSettings();
       this.hide();
     }));
 
-    VjsEvents.on(this.el().querySelector('.vjs-default-button'), 'click', VjsLib.bind(this, function() {
+    Events.on(this.el().querySelector('.vjs-default-button'), 'click', Lib.bind(this, function() {
       this.el().querySelector('.vjs-fg-color > select').selectedIndex = 0;
       this.el().querySelector('.vjs-bg-color > select').selectedIndex = 0;
       this.el().querySelector('.window-color > select').selectedIndex = 0;
@@ -26,15 +26,15 @@ let TextTrackSettings = Component.extend({
       this.updateDisplay();
     }));
 
-    VjsEvents.on(this.el().querySelector('.vjs-fg-color > select'), 'change', VjsLib.bind(this, this.updateDisplay));
-    VjsEvents.on(this.el().querySelector('.vjs-bg-color > select'), 'change', VjsLib.bind(this, this.updateDisplay));
-    VjsEvents.on(this.el().querySelector('.window-color > select'), 'change', VjsLib.bind(this, this.updateDisplay));
-    VjsEvents.on(this.el().querySelector('.vjs-text-opacity > select'), 'change', VjsLib.bind(this, this.updateDisplay));
-    VjsEvents.on(this.el().querySelector('.vjs-bg-opacity > select'), 'change', VjsLib.bind(this, this.updateDisplay));
-    VjsEvents.on(this.el().querySelector('.vjs-window-opacity > select'), 'change', VjsLib.bind(this, this.updateDisplay));
-    VjsEvents.on(this.el().querySelector('.vjs-font-percent select'), 'change', VjsLib.bind(this, this.updateDisplay));
-    VjsEvents.on(this.el().querySelector('.vjs-edge-style select'), 'change', VjsLib.bind(this, this.updateDisplay));
-    VjsEvents.on(this.el().querySelector('.vjs-font-family select'), 'change', VjsLib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.vjs-fg-color > select'), 'change', Lib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.vjs-bg-color > select'), 'change', Lib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.window-color > select'), 'change', Lib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.vjs-text-opacity > select'), 'change', Lib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.vjs-bg-opacity > select'), 'change', Lib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.vjs-window-opacity > select'), 'change', Lib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.vjs-font-percent select'), 'change', Lib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.vjs-edge-style select'), 'change', Lib.bind(this, this.updateDisplay));
+    Events.on(this.el().querySelector('.vjs-font-family select'), 'change', Lib.bind(this, this.updateDisplay));
 
     if (player.options()['persistTextTrackSettings']) {
       this.restoreSettings();
@@ -122,7 +122,7 @@ TextTrackSettings.prototype.saveSettings = function() {
 
   let values = this.getValues();
   try {
-    if (!VjsLib.isEmpty(values)) {
+    if (!Lib.isEmpty(values)) {
       window.localStorage.setItem('vjs-text-track-settings', JSON.stringify(values));
     } else {
       window.localStorage.removeItem('vjs-text-track-settings');

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -1,8 +1,9 @@
 import TextTrackCueList from './text-track-cue-list';
-import * as VjsLib from '../lib';
+import * as Lib from '../lib';
 import * as TextTrackEnum from './text-track-enums';
 import EventEmitter from '../event-emitter';
 import document from 'global/document';
+import window from 'global/window';
 import XHR from '../xhr.js';
 
 /*
@@ -36,7 +37,7 @@ let TextTrack = function(options) {
   }
 
   let tt = this;
-  if (VjsLib.IS_IE8) {
+  if (Lib.IS_IE8) {
     tt = document.createElement('custom');
 
     for (let prop in TextTrack.prototype) {
@@ -50,7 +51,7 @@ let TextTrack = function(options) {
   let kind = TextTrackEnum.TextTrackKind[options['kind']] || 'subtitles';
   let label = options['label'] || '';
   let language = options['language'] || options['srclang'] || '';
-  let id = options['id'] || 'vjs_text_track_' + VjsLib.guid++;
+  let id = options['id'] || 'vjs_text_track_' + Lib.guid++;
 
   if (kind === 'metadata' || kind === 'chapters') {
     mode = 'hidden';
@@ -63,7 +64,7 @@ let TextTrack = function(options) {
   let activeCues = new TextTrackCueList(tt.activeCues_);
 
   let changed = false;
-  let timeupdateHandler = VjsLib.bind(tt, function() {
+  let timeupdateHandler = Lib.bind(tt, function() {
     this['activeCues'];
     if (changed) {
       this['trigger']('cuechange');
@@ -177,12 +178,12 @@ let TextTrack = function(options) {
     tt.loaded_ = true;
   }
 
-  if (VjsLib.IS_IE8) {
+  if (Lib.IS_IE8) {
     return tt;
   }
 };
 
-TextTrack.prototype = VjsLib.obj.create(EventEmitter.prototype);
+TextTrack.prototype = Lib.obj.create(EventEmitter.prototype);
 TextTrack.prototype.constructor = TextTrack;
 
 /*
@@ -240,17 +241,17 @@ let parseCues = function(srcContent, track) {
     track.addCue(cue);
   };
   parser['onparsingerror'] = function(error) {
-    VjsLib.log.error(error);
+    Lib.log.error(error);
   };
 
   parser['parse'](srcContent);
   parser['flush']();
 };
 
-let loadTrack = function(src, track) {
-  XHR(src, VjsLib.bind(this, function(err, response, responseBody){
+var loadTrack = function(src, track) {
+  XHR(src, Lib.bind(this, function(err, response, responseBody){
     if (err) {
-      return VjsLib.log.error(err);
+      return Lib.log.error(err);
     }
 
 
@@ -259,7 +260,7 @@ let loadTrack = function(src, track) {
   }));
 };
 
-let indexOf = function(searchElement, fromIndex) {
+var indexOf = function(searchElement, fromIndex) {
   if (this == null) {
     throw new TypeError('"this" is null or not defined');
   }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -15,7 +15,7 @@ var util = {};
  * @param  {Object} obj2 Overriding object
  * @return {Object}      New object -- obj1 and obj2 will be untouched
  */
-let mergeOptions = function(obj1, obj2){
+var mergeOptions = function(obj1, obj2){
   var key, val1, val2;
 
   // make a copy of obj1 so we're not overwriting original values.

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -14,6 +14,7 @@ import videojs from './core';
 import * as setup from './setup';
 import Component from './component';
 import * as Lib from './lib';
+import * as Util from './util.js';
 
 
 if (typeof HTMLVideoElement === 'undefined') {
@@ -32,7 +33,7 @@ videojs.registerComponent = Component.registerComponent;
 // APIs that will be removed with 5.0, but need them to get tests passing
 // in ES6 transition
 videojs.TOUCH_ENABLED = Lib.TOUCH_ENABLED;
-videojs.util = require('./util');
+videojs.util = Util;
 
 // Probably want to keep this one for 5.0?
 import Player from './player';

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -1,5 +1,5 @@
 import * as VjsUtils from './util';
-import * as VjsLib from './lib';
+import * as Lib from './lib';
 import window from 'global/window';
 
 /**
@@ -66,7 +66,7 @@ var xhr = function(options, callback){
   // Store a reference to the url on the request instance
   request.uri = options.uri;
 
-  let urlInfo = VjsLib.parseUrl(options.uri);
+  let urlInfo = Lib.parseUrl(options.uri);
   let winLoc = window.location;
 
   let successHandler = function(){

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -1,6 +1,6 @@
-var videojs = require('../../src/js/video.js');
-var TestHelpers = require('./test-helpers.js');
-var document = require('global/document');
+import videojs from '../../src/js/video.js';
+import TestHelpers from './test-helpers.js';
+import document from 'global/document';
 
 q.module('Player Minified');
 

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -1,5 +1,6 @@
 var videojs = require('../../src/js/video.js');
 var TestHelpers = require('./test-helpers.js');
+var document = require('global/document');
 
 q.module('Player Minified');
 

--- a/test/unit/button.js
+++ b/test/unit/button.js
@@ -1,5 +1,5 @@
-var Button = require('../../src/js/button.js');
-var TestHelpers = require('./test-helpers.js');
+import Button from '../../src/js/button.js';
+import TestHelpers from './test-helpers.js';
 
 q.module('Button');
 

--- a/test/unit/component.js
+++ b/test/unit/component.js
@@ -1,7 +1,7 @@
-var Component = require('../../src/js/component.js');
-var Lib = require('../../src/js/lib.js');
-var Events = require('../../src/js/events.js');
-var document = require('global/document');
+import Component from '../../src/js/component.js';
+import * as Lib from '../../src/js/lib.js';
+import * as Events from '../../src/js/events.js';
+import document from 'global/document';
 
 q.module('Component', {
   'setup': function() {

--- a/test/unit/component.js
+++ b/test/unit/component.js
@@ -1,6 +1,7 @@
 var Component = require('../../src/js/component.js');
 var Lib = require('../../src/js/lib.js');
 var Events = require('../../src/js/events.js');
+var document = require('global/document');
 
 q.module('Component', {
   'setup': function() {

--- a/test/unit/controls.js
+++ b/test/unit/controls.js
@@ -1,9 +1,9 @@
-var VolumeControl = require('../../src/js/control-bar/volume-control.js').default;
-var MuteToggle = require('../../src/js/control-bar/mute-toggle.js');
-var PlaybackRateMenuButton = require('../../src/js/control-bar/playback-rate-menu-button.js').default;
-var Slider = require('../../src/js/slider.js').default;
-var TestHelpers = require('./test-helpers.js');
-var document = require('global/document');
+import VolumeControl from '../../src/js/control-bar/volume-control.js';
+import MuteToggle from '../../src/js/control-bar/mute-toggle.js';
+import PlaybackRateMenuButton from '../../src/js/control-bar/playback-rate-menu-button.js';
+import Slider from '../../src/js/slider.js';
+import TestHelpers from './test-helpers.js';
+import document from 'global/document';
 
 q.module('Controls');
 

--- a/test/unit/controls.js
+++ b/test/unit/controls.js
@@ -3,6 +3,7 @@ var MuteToggle = require('../../src/js/control-bar/mute-toggle.js');
 var PlaybackRateMenuButton = require('../../src/js/control-bar/playback-rate-menu-button.js').default;
 var Slider = require('../../src/js/slider.js').default;
 var TestHelpers = require('./test-helpers.js');
+var document = require('global/document');
 
 q.module('Controls');
 

--- a/test/unit/core-object.js
+++ b/test/unit/core-object.js
@@ -1,4 +1,4 @@
-var CoreObject = require('../../src/js/core-object.js');
+import CoreObject from '../../src/js/core-object.js';
 
 q.module('Core Object');
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -2,6 +2,7 @@ var videojs = require('../../src/js/core.js');
 var Player = require('../../src/js/player.js');
 var Lib = require('../../src/js/lib.js');
 var Options = require('../../src/js/options.js');
+var document = require('global/document');
 
 q.module('Core');
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -1,8 +1,8 @@
-var videojs = require('../../src/js/core.js');
-var Player = require('../../src/js/player.js');
-var Lib = require('../../src/js/lib.js');
-var Options = require('../../src/js/options.js');
-var document = require('global/document');
+import videojs from '../../src/js/core.js';
+import Player from '../../src/js/player.js';
+import * as Lib from '../../src/js/lib.js';
+import Options from '../../src/js/options.js';
+import document from 'global/document';
 
 q.module('Core');
 

--- a/test/unit/events.js
+++ b/test/unit/events.js
@@ -1,4 +1,5 @@
 var Events = require('../../src/js/events.js');
+var document = require('global/document');
 
 q.module('Events');
 

--- a/test/unit/events.js
+++ b/test/unit/events.js
@@ -1,5 +1,5 @@
-var Events = require('../../src/js/events.js');
-var document = require('global/document');
+import * as Events from '../../src/js/events.js';
+import document from 'global/document';
 
 q.module('Events');
 

--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -1,5 +1,5 @@
-var Flash = require('../../src/js/media/flash.js');
-var document = require('global/document');
+import Flash from '../../src/js/media/flash.js';
+import document from 'global/document';
 
 q.module('Flash');
 

--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -1,4 +1,5 @@
 var Flash = require('../../src/js/media/flash.js');
+var document = require('global/document');
 
 q.module('Flash');
 
@@ -83,7 +84,7 @@ test('currentTime is the seek target during seeking', function() {
         el: function(){
           return {
             appendChild: noop
-          }
+          };
         }
       }, {
         'parentEl': parentEl

--- a/test/unit/lib.js
+++ b/test/unit/lib.js
@@ -1,4 +1,6 @@
 var Lib = require('../../src/js/lib.js');
+var window = require('global/window');
+var document = require('global/document');
 
 q.module('Lib', {
   'setup': function() {

--- a/test/unit/lib.js
+++ b/test/unit/lib.js
@@ -1,6 +1,6 @@
-var Lib = require('../../src/js/lib.js');
-var window = require('global/window');
-var document = require('global/document');
+import * as Lib from '../../src/js/lib.js';
+import window from 'global/window';
+import document from 'global/document';
 
 q.module('Lib', {
   'setup': function() {

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -1,8 +1,8 @@
 var player, tech, el;
 
-var Html5 = require('../../src/js/media/html5.js');
-var Lib = require('../../src/js/lib.js');
-var document = require('global/document');
+import Html5 from '../../src/js/media/html5.js';
+import * as Lib from '../../src/js/lib.js';
+import document from 'global/document';
 
 q.module('HTML5', {
   'setup': function() {

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -2,6 +2,7 @@ var player, tech, el;
 
 var Html5 = require('../../src/js/media/html5.js');
 var Lib = require('../../src/js/lib.js');
+var document = require('global/document');
 
 q.module('HTML5', {
   'setup': function() {

--- a/test/unit/media.js
+++ b/test/unit/media.js
@@ -1,6 +1,6 @@
 var noop = function() {}, clock, oldTextTracks;
 
-var MediaTechController = require('../../src/js/media/media.js');
+import MediaTechController from '../../src/js/media/media.js';
 
 q.module('Media Tech', {
   'setup': function() {

--- a/test/unit/mediafaker.js
+++ b/test/unit/mediafaker.js
@@ -1,9 +1,9 @@
 // Fake a media playback tech controller so that player tests
 // can run without HTML5 or Flash, of which PhantomJS supports neither.
 
-var MediaTechController = require('../../src/js/media/media.js');
-var Lib = require('../../src/js/lib.js');
-var Component = require('../../src/js/component.js');
+import MediaTechController from '../../src/js/media/media.js';
+import * as Lib from '../../src/js/lib.js';
+import Component from '../../src/js/component.js';
 
 /**
  * @constructor

--- a/test/unit/menu.js
+++ b/test/unit/menu.js
@@ -1,5 +1,5 @@
-var MenuButton = require('../../src/js/menu.js').MenuButton;
-var TestHelpers = require('./test-helpers.js');
+import { MenuButton } from '../../src/js/menu.js';
+import TestHelpers from './test-helpers.js';
 
 q.module('MenuButton');
 

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -1,11 +1,11 @@
-var Player = require('../../src/js/player.js');
-var videojs = require('../../src/js/core.js');
-var Options = require('../../src/js/options.js');
-var Lib = require('../../src/js/lib.js');
-var MediaError = require('../../src/js/media-error.js');
-var Html5 = require('../../src/js/media/html5.js');
-var TestHelpers = require('./test-helpers.js');
-var document = require('global/document');
+import Player from '../../src/js/player.js';
+import videojs from '../../src/js/core.js';
+import Options from '../../src/js/options.js';
+import * as Lib from '../../src/js/lib.js';
+import MediaError from '../../src/js/media-error.js';
+import Html5 from '../../src/js/media/html5.js';
+import TestHelpers from './test-helpers.js';
+import document from 'global/document';
 
 q.module('Player', {
   'setup': function() {

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -5,6 +5,7 @@ var Lib = require('../../src/js/lib.js');
 var MediaError = require('../../src/js/media-error.js');
 var Html5 = require('../../src/js/media/html5.js');
 var TestHelpers = require('./test-helpers.js');
+var document = require('global/document');
 
 q.module('Player', {
   'setup': function() {

--- a/test/unit/plugins.js
+++ b/test/unit/plugins.js
@@ -1,6 +1,6 @@
-var Plugin = require('../../src/js/plugins.js');
-var Player = require('../../src/js/player.js');
-var TestHelpers = require('./test-helpers.js');
+import Plugin from '../../src/js/plugins.js';
+import Player from '../../src/js/player.js';
+import TestHelpers from './test-helpers.js';
 
 q.module('Plugins');
 

--- a/test/unit/poster.js
+++ b/test/unit/poster.js
@@ -1,6 +1,7 @@
 var PosterImage = require('../../src/js/poster.js');
 var Lib = require('../../src/js/lib.js');
 var TestHelpers = require('./test-helpers.js');
+var document = require('global/document');
 
 q.module('PosterImage', {
   'setup': function(){

--- a/test/unit/poster.js
+++ b/test/unit/poster.js
@@ -1,7 +1,7 @@
-var PosterImage = require('../../src/js/poster.js');
-var Lib = require('../../src/js/lib.js');
-var TestHelpers = require('./test-helpers.js');
-var document = require('global/document');
+import PosterImage from '../../src/js/poster.js';
+import * as Lib from '../../src/js/lib.js';
+import TestHelpers from './test-helpers.js';
+import document from 'global/document';
 
 q.module('PosterImage', {
   'setup': function(){

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -1,4 +1,4 @@
-var TestHelpers = require('./test-helpers.js');
+import TestHelpers from './test-helpers.js';
 
 q.module('Setup');
 

--- a/test/unit/test-helpers.js
+++ b/test/unit/test-helpers.js
@@ -1,5 +1,7 @@
 var Player = require('../../src/js/player.js');
 var MediaFaker = require('./mediafaker.js');
+var window = require('global/window');
+var document = require('global/document');
 
 var TestHelpers = {
   makeTag: function(){

--- a/test/unit/test-helpers.js
+++ b/test/unit/test-helpers.js
@@ -1,7 +1,7 @@
-var Player = require('../../src/js/player.js');
-var MediaFaker = require('./mediafaker.js');
-var window = require('global/window');
-var document = require('global/document');
+import Player from '../../src/js/player.js';
+import MediaFaker from './mediafaker.js';
+import window from 'global/window';
+import document from 'global/document';
 
 var TestHelpers = {
   makeTag: function(){

--- a/test/unit/tracks/text-track-controls.js
+++ b/test/unit/tracks/text-track-controls.js
@@ -1,6 +1,6 @@
-var TextTrackMenuItem = require('../../../src/js/tracks/text-track-controls').TextTrackMenuItem;
-var TestHelpers = require('../test-helpers.js');
-var Lib = require('../../../src/js/lib.js');
+import { TextTrackMenuItem } from '../../../src/js/tracks/text-track-controls';
+import TestHelpers from '../test-helpers.js';
+import * as Lib from '../../../src/js/lib.js';
 
 q.module('Text Track Controls');
 

--- a/test/unit/tracks/text-track-cue-list.js
+++ b/test/unit/tracks/text-track-cue-list.js
@@ -1,6 +1,5 @@
-q.module('Text Track Cue List');
+import TextTrackCueList from '../../../src/js/tracks/text-track-cue-list.js';
 
-let TTCL = require('../../../src/js/tracks/text-track-cue-list.js');
 let genericTracks = [
   {
     id: '1'
@@ -11,14 +10,16 @@ let genericTracks = [
   }
 ];
 
+q.module('Text Track Cue List');
+
 test('TextTrackCueList\'s length is set correctly', function() {
-  var ttcl = new TTCL(genericTracks);
+  var ttcl = new TextTrackCueList(genericTracks);
 
   equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 });
 
 test('can get cues by id', function() {
-  var ttcl = new TTCL(genericTracks);
+  var ttcl = new TextTrackCueList(genericTracks);
 
   equal(ttcl.getCueById('1').id, 1, 'id "1" has id of "1"');
   equal(ttcl.getCueById('2').id, 2, 'id "2" has id of "2"');
@@ -27,7 +28,7 @@ test('can get cues by id', function() {
 });
 
 test('length is updated when new tracks are added or removed', function() {
-  var ttcl = new TTCL(genericTracks);
+  var ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
   equal(ttcl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
@@ -41,7 +42,7 @@ test('length is updated when new tracks are added or removed', function() {
 });
 
 test('can access items by index', function() {
-  var ttcl = new TTCL(genericTracks),
+  var ttcl = new TextTrackCueList(genericTracks),
       i = 0,
       length = ttcl.length;
 
@@ -53,7 +54,7 @@ test('can access items by index', function() {
 });
 
 test('can access new items by index', function() {
-  var ttcl = new TTCL(genericTracks);
+  var ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
 
@@ -63,7 +64,7 @@ test('can access new items by index', function() {
 });
 
 test('cannot access removed items by index', function() {
-  var ttcl = new TTCL(genericTracks);
+  var ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
   equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
@@ -76,7 +77,7 @@ test('cannot access removed items by index', function() {
 });
 
 test('new item available at old index', function() {
-  var ttcl = new TTCL(genericTracks);
+  var ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
   equal(ttcl[3].id, '100', 'id of item at index 3 is 100');

--- a/test/unit/tracks/text-track-list.js
+++ b/test/unit/tracks/text-track-list.js
@@ -1,6 +1,6 @@
-var TTL = require('../../../src/js/tracks/text-track-list.js');
-var TextTrack = require('../../../src/js/tracks/text-track.js');
-var EventEmitter = require('../../../src/js/event-emitter.js');
+import TextTrackList from '../../../src/js/tracks/text-track-list.js';
+import TextTrack from '../../../src/js/tracks/text-track.js';
+import EventEmitter from '../../../src/js/event-emitter.js';
 
 var noop = Function.prototype;
 var genericTracks = [
@@ -19,13 +19,13 @@ var genericTracks = [
 q.module('Text Track List');
 
 test('TextTrackList\'s length is set correctly', function() {
-  var ttl = new TTL(genericTracks);
+  var ttl = new TextTrackList(genericTracks);
 
   equal(ttl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 });
 
 test('can get text tracks by id', function() {
-  var ttl = new TTL(genericTracks);
+  var ttl = new TextTrackList(genericTracks);
 
   equal(ttl.getTrackById('1').id, 1, 'id "1" has id of "1"');
   equal(ttl.getTrackById('2').id, 2, 'id "2" has id of "2"');
@@ -34,7 +34,7 @@ test('can get text tracks by id', function() {
 });
 
 test('length is updated when new tracks are added or removed', function() {
-  var ttl = new TTL(genericTracks);
+  var ttl = new TextTrackList(genericTracks);
 
   ttl.addTrack_({id: '100', addEventListener: noop});
   equal(ttl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
@@ -48,7 +48,7 @@ test('length is updated when new tracks are added or removed', function() {
 });
 
 test('can access items by index', function() {
-  var ttl = new TTL(genericTracks),
+  var ttl = new TextTrackList(genericTracks),
       i = 0,
       length = ttl.length;
 
@@ -60,7 +60,7 @@ test('can access items by index', function() {
 });
 
 test('can access new items by index', function() {
-  var ttl = new TTL(genericTracks);
+  var ttl = new TextTrackList(genericTracks);
 
   ttl.addTrack_({id: '100', addEventListener: noop});
   equal(ttl[3].id, '100', 'id of item at index 3 is 100');
@@ -69,7 +69,7 @@ test('can access new items by index', function() {
 });
 
 test('cannot access removed items by index', function() {
-  var ttl = new TTL(genericTracks);
+  var ttl = new TextTrackList(genericTracks);
 
   ttl.addTrack_({id: '100', addEventListener: noop});
   ttl.addTrack_({id: '101', addEventListener: noop});
@@ -84,7 +84,7 @@ test('cannot access removed items by index', function() {
 });
 
 test('new item available at old index', function() {
-  var ttl = new TTL(genericTracks);
+  var ttl = new TextTrackList(genericTracks);
 
   ttl.addTrack_({id: '100', addEventListener: noop});
   equal(ttl[3].id, '100', 'id of item at index 3 is 100');
@@ -97,7 +97,7 @@ test('new item available at old index', function() {
 });
 
 test('a "addtrack" event is triggered when new tracks are added', function() {
-  var ttl = new TTL(genericTracks),
+  var ttl = new TextTrackList(genericTracks),
       tracks = 0,
       adds = 0,
       addHandler = function(e) {
@@ -122,7 +122,7 @@ test('a "addtrack" event is triggered when new tracks are added', function() {
 });
 
 test('a "removetrack" event is triggered when tracks are removed', function() {
-  var ttl = new TTL(genericTracks),
+  var ttl = new TextTrackList(genericTracks),
       tracks = 0,
       rms = 0,
       rmHandler = function(e) {
@@ -147,7 +147,7 @@ test('a "removetrack" event is triggered when tracks are removed', function() {
 
 test('trigger "change" event when "modechange" is fired on a track', function() {
   var tt = new EventEmitter(),
-      ttl = new TTL([tt]),
+      ttl = new TextTrackList([tt]),
       changes = 0,
       changeHandler = function() {
         changes++;
@@ -172,7 +172,7 @@ test('trigger "change" event when mode changes on a TextTracl', function() {
           on: noop
         }
       }),
-      ttl = new TTL([tt]),
+      ttl = new TextTrackList([tt]),
       changes = 0,
       changeHandler = function() {
         changes++;

--- a/test/unit/tracks/text-track-settings.js
+++ b/test/unit/tracks/text-track-settings.js
@@ -1,7 +1,7 @@
-var TextTrackSettings = require('../../../src/js/tracks/text-track-settings.js');
-var TestHelpers = require('../test-helpers.js');
-var Events = require('../../../src/js/events.js');
-var window = require('global/window');
+import TextTrackSettings from '../../../src/js/tracks/text-track-settings.js';
+import TestHelpers from '../test-helpers.js';
+import * as Events from '../../../src/js/events.js';
+import window from 'global/window';
 
 var tracks = [{
   kind: 'captions',

--- a/test/unit/tracks/text-track-settings.js
+++ b/test/unit/tracks/text-track-settings.js
@@ -1,6 +1,7 @@
 var TextTrackSettings = require('../../../src/js/tracks/text-track-settings.js');
 var TestHelpers = require('../test-helpers.js');
 var Events = require('../../../src/js/events.js');
+var window = require('global/window');
 
 var tracks = [{
   kind: 'captions',

--- a/test/unit/tracks/text-track.js
+++ b/test/unit/tracks/text-track.js
@@ -1,6 +1,6 @@
-var TextTrack = require('../../../src/js/tracks/text-track.js');
-var window = require('global/window');
-var TestHelpers = require('../test-helpers.js');
+import TextTrack from '../../../src/js/tracks/text-track.js';
+import window from 'global/window';
+import TestHelpers from '../test-helpers.js';
 
 var noop = Function.prototype;
 var defaultPlayer = {

--- a/test/unit/tracks/tracks.js
+++ b/test/unit/tracks/tracks.js
@@ -1,5 +1,3 @@
-q.module('Tracks');
-
 var CaptionsButton = require('../../../src/js/tracks/text-track-controls.js').CaptionsButton;
 var SubtitlesButton = require('../../../src/js/tracks/text-track-controls.js').SubtitlesButton;
 var ChaptersButton = require('../../../src/js/tracks/text-track-controls.js').ChaptersButton;
@@ -11,6 +9,9 @@ var Component = require('../../../src/js/component.js');
 
 var Lib = require('../../../src/js/lib.js');
 var TestHelpers = require('../test-helpers.js');
+var document = require('global/document');
+
+q.module('Tracks');
 
 test('should place title list item into ul', function() {
   var player, chaptersButton;

--- a/test/unit/tracks/tracks.js
+++ b/test/unit/tracks/tracks.js
@@ -1,15 +1,15 @@
-var CaptionsButton = require('../../../src/js/tracks/text-track-controls.js').CaptionsButton;
-var SubtitlesButton = require('../../../src/js/tracks/text-track-controls.js').SubtitlesButton;
-var ChaptersButton = require('../../../src/js/tracks/text-track-controls.js').ChaptersButton;
-var TextTrackDisplay = require('../../../src/js/tracks/text-track-controls.js').TextTrackDisplay;
-var Html5 = require('../../../src/js/media/html5.js');
-var Flash = require('../../../src/js/media/flash.js');
-var MediaTechController = require('../../../src/js/media/media.js');
-var Component = require('../../../src/js/component.js');
+import { CaptionsButton } from '../../../src/js/tracks/text-track-controls.js';
+import { SubtitlesButton } from '../../../src/js/tracks/text-track-controls.js';
+import { ChaptersButton } from '../../../src/js/tracks/text-track-controls.js';
+import { TextTrackDisplay } from '../../../src/js/tracks/text-track-controls.js';
+import Html5 from '../../../src/js/media/html5.js';
+import Flash from '../../../src/js/media/flash.js';
+import MediaTechController from '../../../src/js/media/media.js';
+import Component from '../../../src/js/component.js';
 
-var Lib = require('../../../src/js/lib.js');
-var TestHelpers = require('../test-helpers.js');
-var document = require('global/document');
+import * as Lib from '../../../src/js/lib.js';
+import TestHelpers from '../test-helpers.js';
+import document from 'global/document';
 
 q.module('Tracks');
 

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -1,4 +1,4 @@
-var Util = require('../../src/js/util.js');
+import * as Util from '../../src/js/util.js';
 
 q.module('Util');
 


### PR DESCRIPTION
Had to revert a number of the lets back to vars, specfically for exported vars.
For examples `export { foo, bar }` would throw undefined errors if foo and
bar were defined with let

Also changed all VjsLib and VjsEvents to just Lib and Events.